### PR TITLE
Optional createdById column 

### DIFF
--- a/prisma/migrations/20231109172100_optional_created_by_id/migration.sql
+++ b/prisma/migrations/20231109172100_optional_created_by_id/migration.sql
@@ -1,0 +1,8 @@
+-- DropForeignKey
+ALTER TABLE "Course" DROP CONSTRAINT "Course_createdById_fkey";
+
+-- AlterTable
+ALTER TABLE "Course" ALTER COLUMN "createdById" DROP NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "Course" ADD CONSTRAINT "Course_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -41,8 +41,8 @@ model Course {
   maxStudents Int
   students    User[]
   tags        Tag[]
-  createdBy   User       @relation(name: "createdCourses", references: [id], fields: [createdById])
-  createdById String
+  createdBy   User?      @relation(name: "createdCourses", references: [id], fields: [createdById])
+  createdById String?
   calendar    Calendar[]
 }
 


### PR DESCRIPTION
Make `createdById` column temporarily optional so that migrations can be run for staging