### PR TITLE
#162/feat/add optional last cancel date

### DIFF
--- a/prisma/migrations/20231114195722_add_last_cancel_date/migration.sql
+++ b/prisma/migrations/20231114195722_add_last_cancel_date/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Course" ADD COLUMN     "lastCancelDate" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -39,6 +39,7 @@ model Course {
   startDate      DateTime
   endDate        DateTime
   lastEnrollDate DateTime?
+  lastCancelDate DateTime?
   maxStudents    Int
   students       User[]
   tags           Tag[]

--- a/src/app/[lang]/locales/en/app.json
+++ b/src/app/[lang]/locales/en/app.json
@@ -17,6 +17,7 @@
     "startDate": "Start date",
     "endDate": "End date",
     "lastEnrollDate": "Last date to enroll (optional)",
+    "lastCancelDate": "Last date to cancel enrollment (optional)",
     "maxStudents": "Max students",
     "submit": "Submit",
     "tags": "Tags"

--- a/src/app/api/course/enroll/route.test.ts
+++ b/src/app/api/course/enroll/route.test.ts
@@ -3,7 +3,6 @@ import { POST, PUT } from './route';
 import { clearDatabase, prisma } from '@/lib/prisma';
 import { NextRequest } from 'next/server';
 import { createMocks } from 'node-mocks-http';
-import { minCancelTimeMs } from '@/lib/zod/courses';
 
 const testUser = {
   id: 'cloeouh4x0000qiexq8tqzvh7',
@@ -19,30 +18,29 @@ const newCourse = {
   createdById: testUser.id,
 };
 
-const startMsSoon = Date.now() + Math.round(minCancelTimeMs / 2);
-const startDateSoon = new Date(startMsSoon);
-const endDateSoon = new Date(startMsSoon + 24 * 60 * 60 * 1000); // 1 day course
-
-const startingSoonCourse = {
-  name: 'Git Fundamentals',
-  description:
-    'This course will walk you through the fundamentals of using Git for version control. You will learn how to create a local Git repository, commit files and push your changes to a remote repository. The course will introduce you to concepts like the working copy and the staging area and teach you how to organise you repository using tags and branches. You will learn how to make pull requests and merge branches, and tackle merge conflicts when they arise.',
-  startDate: startDateSoon,
-  endDate: endDateSoon,
-  maxStudents: 8,
-  createdById: testUser.id,
-};
-
-const startDateYesterday = new Date(Date.now() - 24 * 60 * 60 * 1000);
-const endDateTomorrow = new Date(Date.now() + 24 * 60 * 60 * 1000);
+const dateYesterday = new Date(Date.now() - 24 * 60 * 60 * 1000);
+const dateTomorrow = new Date(Date.now() + 24 * 60 * 60 * 1000);
+const dateTomorrowEvening = new Date(Date.now() + 32 * 60 * 60 * 1000);
 
 const pastDeadlineToEnrollCourse = {
   name: 'Git Fundamentals',
   description:
     'This course will walk you through the fundamentals of using Git for version control. You will learn how to create a local Git repository, commit files and push your changes to a remote repository. The course will introduce you to concepts like the working copy and the staging area and teach you how to organise you repository using tags and branches. You will learn how to make pull requests and merge branches, and tackle merge conflicts when they arise.',
-  startDate: startDateYesterday,
-  endDate: endDateTomorrow,
-  lastEnrollDate: startDateYesterday,
+  startDate: dateYesterday,
+  endDate: dateTomorrow,
+  lastEnrollDate: dateYesterday,
+  maxStudents: 8,
+  createdById: testUser.id,
+};
+
+const pastDeadlineToCancelCourse = {
+  name: 'Git Fundamentals',
+  description:
+    'This course will walk you through the fundamentals of using Git for version control. You will learn how to create a local Git repository, commit files and push your changes to a remote repository. The course will introduce you to concepts like the working copy and the staging area and teach you how to organise you repository using tags and branches. You will learn how to make pull requests and merge branches, and tackle merge conflicts when they arise.',
+  startDate: dateTomorrow,
+  endDate: dateTomorrowEvening,
+  lastEnrollDate: dateYesterday,
+  lastCancelDate: dateYesterday,
   maxStudents: 8,
   createdById: testUser.id,
 };
@@ -215,7 +213,7 @@ describe('Course enrollment API tests', () => {
     it('cancelling enrollment after cancellation deadline is not possible', async () => {
       const enrolledCourse = await prisma.course.create({
         data: {
-          ...startingSoonCourse,
+          ...pastDeadlineToCancelCourse,
           students: {
             connect: [{ id: testUser.id }],
           },

--- a/src/app/api/course/enroll/route.ts
+++ b/src/app/api/course/enroll/route.ts
@@ -8,9 +8,7 @@ import {
   errorResponse,
 } from '@/lib/response/responseUtil';
 import { handleCommonErrors } from '@/lib/response/errorUtil';
-import { msUntilStart, isPastDeadline } from '@/lib/timedateutils';
-import { minCancelTimeMs } from '@/lib/zod/courses';
-
+import { isPastDeadline } from '@/lib/timedateutils';
 import { insertCourseToCalendar, deleteCourseFromCalendar } from '@/lib/google';
 
 export async function POST(request: NextRequest) {
@@ -127,7 +125,7 @@ export async function PUT(request: NextRequest) {
       });
     }
 
-    if (msUntilStart(course.startDate) < minCancelTimeMs) {
+    if (isPastDeadline(course.lastCancelDate)) {
       return errorResponse({
         message: 'No cancelling allowed after cancellation deadline',
         statusCode: StatusCodeType.UNPROCESSABLE_CONTENT,

--- a/src/app/api/course/route.test.ts
+++ b/src/app/api/course/route.test.ts
@@ -202,6 +202,7 @@ describe('Course API tests', () => {
       startDate: new Date(Date.now() + 1000 * 60 * 60 * 24),
       endDate: new Date(Date.now() + 1000 * 60 * 60 * 24 * 2),
       lastEnrollDate: new Date(Date.now() + 1000 * 60 * 60 * 24),
+      lastCancelDate: new Date(Date.now() + 1000 * 60 * 60 * 12),
       maxStudents: 200,
       createdById: testUser.id,
       tags: [],
@@ -212,6 +213,7 @@ describe('Course API tests', () => {
       startDate: courseDataWithDate.startDate.toString(),
       endDate: courseDataWithDate.endDate.toString(),
       lastEnrollDate: courseDataWithDate.lastEnrollDate.toString(),
+      lastCancelDate: courseDataWithDate.lastCancelDate.toString(),
     };
 
     it('Should return 404 when course does not exist in the db', async () => {

--- a/src/components/CourseForm/CourseForm.test.tsx
+++ b/src/components/CourseForm/CourseForm.test.tsx
@@ -75,7 +75,7 @@ describe('Course Form New Course Tests', () => {
     });
   });
 
-  it('Form is submitted with correct values when no last enroll date is given', async () => {
+  it('Form is submitted with correct values when no last enroll or cancel dates are given', async () => {
     const inputValues = {
       name: 'New course',
       description: 'A test course',
@@ -159,6 +159,51 @@ describe('Course Form New Course Tests', () => {
       });
     });
   });
+
+  it('Form is submitted with correct values when last cancel date is given', async () => {
+    const inputValues = {
+      name: 'New course',
+      description: 'A test course',
+      startDate: '2053-09-13T09:30',
+      endDate: '2053-10-13T17:30',
+      lastCancelDate: '2053-09-13T09:30',
+      maxStudents: '12',
+      tags: [],
+    };
+
+    const name = screen.getByTestId('courseFormName');
+    const description = screen.getByTestId('courseFormDescription');
+    const startDate = screen.getByTestId('courseFormStartDate');
+    const endDate = screen.getByTestId('courseFormEndDate');
+    const lastCancelDate = screen.getByTestId('courseFormLastCancelDate');
+    const maxStudents = screen.getByTestId('courseFormMaxStudents');
+    const submitButton = screen.getByTestId('courseFormSubmit');
+
+    await userEvent.type(name, inputValues.name);
+    await userEvent.type(description, inputValues.description);
+
+    fireEvent.change(startDate, { target: { value: inputValues.startDate } });
+    fireEvent.change(endDate, { target: { value: inputValues.endDate } });
+    fireEvent.change(lastCancelDate, {
+      target: { value: inputValues.lastCancelDate },
+    });
+
+    await userEvent.clear(maxStudents);
+    await userEvent.type(maxStudents, inputValues.maxStudents);
+
+    await userEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(mockFetch).toBeCalledWith('/api/course', {
+        ...inputValues,
+        endDate: new Date(inputValues.endDate),
+        maxStudents: Number(inputValues.maxStudents),
+        startDate: new Date(inputValues.startDate),
+        lastEnrollDate: null,
+        lastCancelDate: new Date(inputValues.lastCancelDate),
+      });
+    });
+  });
 });
 
 describe('Course Form Course Edit Tests', () => {
@@ -214,7 +259,7 @@ describe('Course Form Course Edit Tests', () => {
     );
   });
 
-  it('Form is filled with course values in Edit Mode when lastEnrollDate is null', async () => {
+  it('Form is filled with course values in Edit Mode when last enroll and last cancel dates are null', async () => {
     const course = {
       id: '1234',
       createdById: '30',
@@ -223,7 +268,7 @@ describe('Course Form Course Edit Tests', () => {
       startDate: new Date(),
       endDate: new Date(),
       lastEnrollDate: null,
-      lastCancelDate: new Date(),
+      lastCancelDate: null,
       maxStudents: 55,
       tags: [],
     };
@@ -255,9 +300,7 @@ describe('Course Form Course Edit Tests', () => {
     expect(startDate.value).toBe(dateToDateTimeLocal(course.startDate));
     expect(endDate.value).toBe(dateToDateTimeLocal(course.endDate));
     expect(lastEnrollDate.value).toBe('');
-    expect(lastCancelDate.value).toBe(
-      dateToDateTimeLocal(course.lastCancelDate)
-    );
+    expect(lastCancelDate.value).toBe('');
   });
 
   it('Form is submitted with correct values in Edit Mode', async () => {
@@ -291,7 +334,7 @@ describe('Course Form Course Edit Tests', () => {
     });
   });
 
-  it('Form is submitted with correct values in Edit Mode when last enroll date is null', async () => {
+  it('Form is submitted with correct values in Edit Mode when last enroll and last cancel dates are null', async () => {
     const course = {
       id: '1234',
       createdById: '30',
@@ -300,7 +343,7 @@ describe('Course Form Course Edit Tests', () => {
       startDate: new Date(Date.now() + 1000 * 60 * 60 * 24),
       endDate: new Date(Date.now() + 1000 * 60 * 60 * 24 * 2),
       lastEnrollDate: null,
-      lastCancelDate: new Date(Date.now() + 1000 * 60 * 60 * 12),
+      lastCancelDate: null,
       maxStudents: 55,
       tags: [],
     };
@@ -316,7 +359,7 @@ describe('Course Form Course Edit Tests', () => {
         startDate: new Date(course.startDate),
         endDate: new Date(course.endDate),
         lastEnrollDate: null,
-        lastCancelDate: new Date(course.lastCancelDate),
+        lastCancelDate: null,
         maxStudents: Number(course.maxStudents),
       });
     });

--- a/src/components/CourseForm/CourseForm.test.tsx
+++ b/src/components/CourseForm/CourseForm.test.tsx
@@ -110,6 +110,7 @@ describe('Course Form New Course Tests', () => {
         maxStudents: Number(inputValues.maxStudents),
         startDate: new Date(inputValues.startDate),
         lastEnrollDate: null,
+        lastCancelDate: null,
       });
     });
   });
@@ -154,6 +155,7 @@ describe('Course Form New Course Tests', () => {
         maxStudents: Number(inputValues.maxStudents),
         startDate: new Date(inputValues.startDate),
         lastEnrollDate: new Date(inputValues.lastEnrollDate),
+        lastCancelDate: null,
       });
     });
   });
@@ -173,6 +175,7 @@ describe('Course Form Course Edit Tests', () => {
       startDate: courseStart,
       endDate: courseEnd,
       lastEnrollDate: oneDayBeforeStart,
+      lastCancelDate: oneDayBeforeStart,
       maxStudents: 55,
       tags: [],
     };
@@ -190,6 +193,9 @@ describe('Course Form Course Edit Tests', () => {
     const endDate = screen.getByTestId('courseFormEndDate') as HTMLInputElement;
     const lastEnrollDate = screen.getByTestId(
       'courseFormLastEnrollDate'
+    ) as HTMLInputElement;
+    const lastCancelDate = screen.getByTestId(
+      'courseFormLastCancelDate'
     ) as HTMLInputElement;
     const maxStudents = screen.getByTestId(
       'courseFormMaxStudents'
@@ -203,6 +209,9 @@ describe('Course Form Course Edit Tests', () => {
     expect(lastEnrollDate.value).toBe(
       dateToDateTimeLocal(course.lastEnrollDate)
     );
+    expect(lastCancelDate.value).toBe(
+      dateToDateTimeLocal(course.lastCancelDate)
+    );
   });
 
   it('Form is filled with course values in Edit Mode when lastEnrollDate is null', async () => {
@@ -214,6 +223,7 @@ describe('Course Form Course Edit Tests', () => {
       startDate: new Date(),
       endDate: new Date(),
       lastEnrollDate: null,
+      lastCancelDate: new Date(),
       maxStudents: 55,
       tags: [],
     };
@@ -232,6 +242,9 @@ describe('Course Form Course Edit Tests', () => {
     const lastEnrollDate = screen.getByTestId(
       'courseFormLastEnrollDate'
     ) as HTMLInputElement;
+    const lastCancelDate = screen.getByTestId(
+      'courseFormLastCancelDate'
+    ) as HTMLInputElement;
     const maxStudents = screen.getByTestId(
       'courseFormMaxStudents'
     ) as HTMLInputElement;
@@ -242,6 +255,9 @@ describe('Course Form Course Edit Tests', () => {
     expect(startDate.value).toBe(dateToDateTimeLocal(course.startDate));
     expect(endDate.value).toBe(dateToDateTimeLocal(course.endDate));
     expect(lastEnrollDate.value).toBe('');
+    expect(lastCancelDate.value).toBe(
+      dateToDateTimeLocal(course.lastCancelDate)
+    );
   });
 
   it('Form is submitted with correct values in Edit Mode', async () => {
@@ -253,6 +269,7 @@ describe('Course Form Course Edit Tests', () => {
       startDate: courseStart,
       endDate: courseEnd,
       lastEnrollDate: oneDayBeforeStart,
+      lastCancelDate: oneDayBeforeStart,
       maxStudents: 55,
       tags: [],
     };
@@ -269,6 +286,7 @@ describe('Course Form Course Edit Tests', () => {
         maxStudents: Number(course.maxStudents),
         startDate: new Date(course.startDate),
         lastEnrollDate: new Date(course.lastEnrollDate),
+        lastCancelDate: new Date(course.lastCancelDate),
       });
     });
   });
@@ -282,6 +300,7 @@ describe('Course Form Course Edit Tests', () => {
       startDate: new Date(Date.now() + 1000 * 60 * 60 * 24),
       endDate: new Date(Date.now() + 1000 * 60 * 60 * 24 * 2),
       lastEnrollDate: null,
+      lastCancelDate: new Date(Date.now() + 1000 * 60 * 60 * 12),
       maxStudents: 55,
       tags: [],
     };
@@ -294,10 +313,11 @@ describe('Course Form Course Edit Tests', () => {
     await waitFor(() => {
       expect(mockFetch).toBeCalledWith('/api/course', {
         ...course,
-        endDate: new Date(course.endDate),
-        maxStudents: Number(course.maxStudents),
         startDate: new Date(course.startDate),
+        endDate: new Date(course.endDate),
         lastEnrollDate: null,
+        lastCancelDate: new Date(course.lastCancelDate),
+        maxStudents: Number(course.maxStudents),
       });
     });
   });

--- a/src/components/CourseForm/CourseForm.tsx
+++ b/src/components/CourseForm/CourseForm.tsx
@@ -64,6 +64,7 @@ export default function CourseForm({
             startDate: undefined,
             endDate: undefined,
             lastEnrollDate: undefined,
+            lastCancelDate: undefined,
             tags: courseData.tags.map((tag) => tag.name),
           }
         : { maxStudents: 10 }),
@@ -250,6 +251,25 @@ export default function CourseForm({
             }}
           />
           <FormFieldError error={errors.lastEnrollDate} />
+
+          <InputLabel htmlFor="courseFormLastCancelDate">
+            {t('CourseForm.lastCancelDate')}
+          </InputLabel>
+          <Input
+            {...register('lastCancelDate')}
+            defaultValue={
+              courseData && courseData.lastCancelDate
+                ? dateToDateTimeLocal(courseData.lastCancelDate)
+                : ''
+            }
+            id="courseFormLastCancelDate"
+            type="datetime-local"
+            error={!!errors.lastCancelDate}
+            inputProps={{
+              'data-testid': 'courseFormLastCancelDate',
+            }}
+          />
+          <FormFieldError error={errors.lastCancelDate} />
 
           <InputLabel htmlFor="courseFormMaxStudents">
             {t('CourseForm.maxStudents')}

--- a/src/components/CourseModal/CancelEnroll.test.tsx
+++ b/src/components/CourseModal/CancelEnroll.test.tsx
@@ -1,0 +1,67 @@
+import { screen } from '@testing-library/react';
+import CancelEnroll from './CancelEnroll';
+import { renderWithTheme } from '@/lib/test-utils';
+
+jest.mock('../../lib/i18n/client', () => ({
+  // this mock makes sure any components using the translate hook can use it without a warning being shown
+  useTranslation: () => {
+    return {
+      t: (str: string) => str,
+      i18n: {
+        changeLanguage: () => new Promise(() => {}),
+      },
+    };
+  },
+}));
+
+jest.mock('next/navigation', () => ({
+  useRouter() {
+    return {
+      refresh: jest.fn(),
+    };
+  },
+}));
+
+const mockFetch = jest.fn((...args: any[]) =>
+  Promise.resolve({
+    json: () => Promise.resolve({ args: args }),
+    ok: true,
+  })
+);
+
+jest.mock('../../lib/response/fetchUtil', () => ({
+  update: (...args: any[]) => mockFetch(...args),
+}));
+
+const tomorrow = new Date(Date.now() + 24 * 60 * 60 * 1000);
+const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+describe('CancelEnroll component', () => {
+  it('renders cancel button if cancelling is still allowed', () => {
+    renderWithTheme(
+      <CancelEnroll courseId="12345" lastCancelDate={tomorrow} lang="en" />
+    );
+
+    const cancelButton = screen.queryByRole('button', {
+      name: /cancel enrollment/i,
+    });
+    expect(cancelButton).toBeInTheDocument;
+  });
+
+  it('renders no cancellation button if it is past the cancellation deadline', () => {
+    renderWithTheme(
+      <CancelEnroll courseId="12345" lastCancelDate={yesterday} lang="en" />
+    );
+
+    const cancelButton = screen.queryByRole('button', {
+      name: /cancel enrollment/i,
+    });
+    expect(cancelButton).not.toBeInTheDocument;
+
+    expect(
+      screen.findByText(
+        'The course starts soon. Contact the trainer if you want to cancel your enrollment.'
+      )
+    ).toBeVisible;
+  });
+});

--- a/src/components/CourseModal/CancelEnroll.tsx
+++ b/src/components/CourseModal/CancelEnroll.tsx
@@ -7,18 +7,21 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useMessage } from '../Providers/MessageProvider';
 import { update } from '@/lib/response/fetchUtil';
-import { msUntilStart } from '@/lib/timedateutils';
-import { minCancelTimeMs } from '@/lib/zod/courses';
+import { isPastDeadline } from '@/lib/timedateutils';
 import { DictProps } from '@/lib/i18n';
 import { useTranslation } from '@i18n/client';
 import InfoBox from './InfoBox';
 
 interface Props extends DictProps {
   courseId: string;
-  startDate: Date;
+  lastCancelDate: Date | null;
 }
 
-export default function CancelEnroll({ courseId, startDate, lang }: Props) {
+export default function CancelEnroll({
+  courseId,
+  lastCancelDate,
+  lang,
+}: Props) {
   const { t } = useTranslation(lang, 'components');
   const router = useRouter();
   const [backdropOpen, setBackdropOpen] = useState(false);
@@ -30,11 +33,7 @@ export default function CancelEnroll({ courseId, startDate, lang }: Props) {
     router.refresh();
   };
 
-  const cancellingAllowed = (startDate: Date): boolean => {
-    return msUntilStart(startDate) > minCancelTimeMs;
-  };
-
-  if (!cancellingAllowed(startDate)) {
+  if (isPastDeadline(lastCancelDate)) {
     return (
       <InfoBox
         infoText={t('CancelEnroll.pastCancellationDate')}

--- a/src/components/CourseModal/CourseModal.tsx
+++ b/src/components/CourseModal/CourseModal.tsx
@@ -156,8 +156,8 @@ export default function CourseModal({
               isUserEnrolled={isUserEnrolled}
               courseId={course.id}
               isCourseFull={isCourseFull}
-              startDate={course.startDate}
               lastEnrollDate={course.lastEnrollDate}
+              lastCancelDate={course.lastCancelDate}
             />
           </Box>
           <Box sx={{ flex: 1 }}></Box>

--- a/src/components/CourseModal/EnrollHolder.test.tsx
+++ b/src/components/CourseModal/EnrollHolder.test.tsx
@@ -43,8 +43,8 @@ describe('EnrollHolder component', () => {
         isUserEnrolled={false}
         courseId="123"
         isCourseFull={false}
-        startDate={new Date()}
         lastEnrollDate={null}
+        lastCancelDate={null}
         lang="en"
       />
     );
@@ -59,8 +59,8 @@ describe('EnrollHolder component', () => {
         isUserEnrolled={true}
         courseId="123"
         isCourseFull={false}
-        startDate={new Date()}
         lastEnrollDate={null}
+        lastCancelDate={null}
         lang="en"
       />
     );
@@ -77,8 +77,8 @@ describe('EnrollHolder component', () => {
         isUserEnrolled={false}
         courseId="123"
         isCourseFull={true}
-        startDate={new Date()}
         lastEnrollDate={null}
+        lastCancelDate={null}
         lang="en"
       />
     );
@@ -93,8 +93,8 @@ describe('EnrollHolder component', () => {
         isUserEnrolled={false}
         courseId="123"
         isCourseFull={false}
-        startDate={new Date()}
         lastEnrollDate={yesterday}
+        lastCancelDate={null}
         lang="en"
       />
     );

--- a/src/components/CourseModal/EnrollHolder.tsx
+++ b/src/components/CourseModal/EnrollHolder.tsx
@@ -13,16 +13,16 @@ interface Props extends DictProps {
   isUserEnrolled: boolean;
   courseId: string;
   isCourseFull: boolean;
-  startDate: Date;
   lastEnrollDate: Date | null;
+  lastCancelDate: Date | null;
 }
 
 export default function EnrollHolder({
   isUserEnrolled,
   courseId,
   isCourseFull,
-  startDate,
   lastEnrollDate,
+  lastCancelDate,
   lang,
 }: Props) {
   const { t } = useTranslation(lang, 'components');
@@ -30,7 +30,11 @@ export default function EnrollHolder({
     return (
       <>
         <Typography>{t('EnrollHolder.confirmMessage')}</Typography>
-        <CancelEnroll courseId={courseId} startDate={startDate} lang={lang} />
+        <CancelEnroll
+          courseId={courseId}
+          lastCancelDate={lastCancelDate}
+          lang={lang}
+        />
       </>
     );
   }

--- a/src/lib/zod/courses.ts
+++ b/src/lib/zod/courses.ts
@@ -46,7 +46,7 @@ const withRefine = <O extends CourseSchemaType, T extends z.ZodTypeDef, I>(
       {
         message:
           'The last date to cancel enrollment cannot be after the end date of the course',
-        path: ['lastEnrollDate'],
+        path: ['lastCancelDate'],
       }
     );
 };

--- a/src/lib/zod/courses.ts
+++ b/src/lib/zod/courses.ts
@@ -34,6 +34,20 @@ const withRefine = <O extends CourseSchemaType, T extends z.ZodTypeDef, I>(
           'The last date to enroll cannot be after the end date of the course',
         path: ['lastEnrollDate'],
       }
+    )
+    .refine(
+      ({ endDate, lastCancelDate }) => {
+        // don't show error if course end date or last date to cancel is still empty
+        if (!endDate || !lastCancelDate) {
+          return true;
+        }
+        return lastCancelDate.getTime() < endDate.getTime();
+      },
+      {
+        message:
+          'The last date to cancel enrollment cannot be after the end date of the course',
+        path: ['lastEnrollDate'],
+      }
     );
 };
 
@@ -57,11 +71,15 @@ const courseSchemaBase = z
           message: 'Start date cannot be in the past',
         }
       ),
+    endDate: z.string().min(1, 'End date is required').pipe(z.coerce.date()),
     lastEnrollDate: z.preprocess(
       (value) => (!value ? null : value),
       z.coerce.date().nullable()
     ),
-    endDate: z.string().min(1, 'End date is required').pipe(z.coerce.date()),
+    lastCancelDate: z.preprocess(
+      (value) => (!value ? null : value),
+      z.coerce.date().nullable()
+    ),
     maxStudents: z.number().min(1, 'Max students is required'),
     tags: z.array(z.string().min(1, 'Tag name cannot be empty')),
   })


### PR DESCRIPTION
### In this pull request: 

- This PR makes it possible for admins and trainers to freely set the last date allowed to cancel one's enrollment for a course, replacing the the previous general cancellation deadline of 48 h before course start. 
- Adding a last cancellation date for a course is optional; if no last cancel date is set, a student can cancel their enrollment at any point.
- The only validation rule enforced for the last cancel date for now is that it cannot be later than the ending date of the course. Setting a last cancel date after the course start date is allowed. It is also possible to set a last cancel date in the past, to avoid validation problems if there is a need to update some other course data after the last cancellation date has passed.
- If it is past the last cancellation date for a course, the Cancel enrollment button in the Course modal is replaced by an info text telling the user that it is no longer possible to cancel one's enrollment through the web app.