### PR TITLE
MUI typography custom headers

### DIFF
--- a/src/app/[lang]/admin/dashboard/CreateTag.tsx
+++ b/src/app/[lang]/admin/dashboard/CreateTag.tsx
@@ -24,7 +24,7 @@ export default function CreateTag({ lang, existingTagLabel, tags }: Props) {
         padding: '1rem',
       }}
     >
-      <Typography variant="h4" component="h2" sx={{ marginBottom: '2rem' }}>
+      <Typography variant="h2" sx={{ marginBottom: '2rem' }}>
         {existingTagLabel}
       </Typography>
       <TagList lang={lang} tags={tags} />

--- a/src/app/[lang]/admin/dashboard/page.tsx
+++ b/src/app/[lang]/admin/dashboard/page.tsx
@@ -20,9 +20,7 @@ export default async function AdminDashboardPage({ params }: Props) {
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
-      <Typography variant="h3" component="h1">
-        {t('DashboardTitle')}
-      </Typography>
+      <Typography variant="h1">{t('DashboardTitle')}</Typography>
       <CreateTag
         existingTagLabel={t('CreateTag.tagsLabel')}
         tags={tags}

--- a/src/components/CourseCard/index.tsx
+++ b/src/components/CourseCard/index.tsx
@@ -82,7 +82,7 @@ const CourseCard = ({ course, enrolls }: Props) => {
           }}
         >
           <Box>
-            <Typography variant="h5" m={2}>
+            <Typography variant="h3" m={2}>
               {course.name}
             </Typography>
           </Box>

--- a/src/components/CourseForm/CourseForm.tsx
+++ b/src/components/CourseForm/CourseForm.tsx
@@ -97,7 +97,7 @@ export default function CourseForm({
         }}
       >
         <Typography
-          variant="h4"
+          variant="h2"
           color={palette.black.main}
           textAlign="center"
           marginBottom={1}

--- a/src/components/CourseList/CourseList.tsx
+++ b/src/components/CourseList/CourseList.tsx
@@ -132,9 +132,8 @@ export default function CourseList({
           }}
         >
           <Typography
-            variant="h6"
+            variant="h4"
             style={{
-              fontWeight: 500,
               color: palette.white.main,
             }}
           >

--- a/src/components/CourseModal/CourseModal.tsx
+++ b/src/components/CourseModal/CourseModal.tsx
@@ -75,7 +75,7 @@ export default function CourseModal({
         }}
       >
         <CourseModalCloseButton lang={lang} />
-        <Typography variant="h3">{course.name}</Typography>
+        <Typography variant="h1">{course.name}</Typography>
         <Typography sx={{ my: 2 }}>
           <LocalizedDateTime
             variant="range-long"
@@ -119,7 +119,7 @@ export default function CourseModal({
           ))}
         </Box>
 
-        <Typography variant="h6" sx={{ my: 2, color: 'white.main' }}>
+        <Typography variant="h4" sx={{ my: 2, color: 'white.main' }}>
           {description}
         </Typography>
 

--- a/src/components/ProfileView/ProfileUserDetails.tsx
+++ b/src/components/ProfileView/ProfileUserDetails.tsx
@@ -45,7 +45,7 @@ export default function ProfileUserDetails({
         }}
       />
       <Typography
-        variant="h5"
+        variant="h3"
         gutterBottom
         style={{ color: palette.white.main }}
       >

--- a/src/components/Providers/ThemeRegistry/theme.ts
+++ b/src/components/Providers/ThemeRegistry/theme.ts
@@ -73,21 +73,39 @@ let theme = createTheme({
     htmlFontSize: 16, // root
     h1: {
       fontSize: '3rem', // 3 * 16 = 48
+      fontWeight: 400,
+      lineHeight: 1.167,
+      letterSpacing: '0em',
     },
     h2: {
       fontSize: '2.125rem', // 2.125 * 16 = 34
+      fontWeight: 400,
+      lineHeight: 1.235,
+      letterSpacing: '0.00735em',
     },
     h3: {
       fontSize: '1.5rem', // 1.5 * 16 = 24
+      fontWeight: 400,
+      lineHeight: 1.167,
+      letterSpacing: '0em',
     },
     h4: {
       fontSize: '1.25rem', // 1.25 * 26 = 20
+      fontWeight: 500,
+      lineHeight: 1.6,
+      letterSpacing: '0.0075em',
     },
     h5: {
       fontSize: '1.125rem', // 1.125 * 16 = 18
+      fontWeight: 500,
+      lineHeight: 1.6,
+      letterSpacing: '0.0075em',
     },
     h6: {
       fontSize: '1.075rem', // 1.075 * 16 = 17.2
+      fontWeight: 500,
+      lineHeight: 1.6,
+      letterSpacing: '0.0075em',
     },
   },
   components: {

--- a/src/components/Providers/ThemeRegistry/theme.ts
+++ b/src/components/Providers/ThemeRegistry/theme.ts
@@ -69,6 +69,27 @@ let theme = createTheme({
       main: '#ffffff',
     },
   },
+  typography: {
+    htmlFontSize: 16, // root
+    h1: {
+      fontSize: '3rem', // 3 * 16 = 48
+    },
+    h2: {
+      fontSize: '2.125rem', // 2.125 * 16 = 34
+    },
+    h3: {
+      fontSize: '1.5rem', // 1.5 * 16 = 24
+    },
+    h4: {
+      fontSize: '1.25rem', // 1.25 * 26 = 20
+    },
+    h5: {
+      fontSize: '1.125rem', // 1.125 * 16 = 18
+    },
+    h6: {
+      fontSize: '1.075rem', // 1.075 * 16 = 17.2
+    },
+  },
   components: {
     MuiAppBar: {
       styleOverrides: {

--- a/src/components/TextEditor/MenuBar.tsx
+++ b/src/components/TextEditor/MenuBar.tsx
@@ -98,17 +98,17 @@ export const MenuBar = ({ lang }: DictProps) => {
             disableUnderline
           >
             <MenuItem sx={menuItemSx} value={'header1'}>
-              <Typography variant="h6">
+              <Typography variant="h4">
                 {t('TextEditor.Dropdown.header1')}
               </Typography>
             </MenuItem>
             <MenuItem sx={menuItemSx} value={'header2'}>
-              <Typography variant="h6">
+              <Typography variant="h4">
                 {t('TextEditor.Dropdown.header2')}
               </Typography>
             </MenuItem>
             <MenuItem sx={menuItemSx} value={'header3'}>
-              <Typography variant="h6">
+              <Typography variant="h4">
                 {t('TextEditor.Dropdown.header3')}
               </Typography>
             </MenuItem>

--- a/src/components/UnauthorizedError/index.tsx
+++ b/src/components/UnauthorizedError/index.tsx
@@ -22,7 +22,7 @@ export default function UnauthorizedError({ lang }: Props) {
         p: 10,
       }}
     >
-      <Typography variant="h4" sx={{ m: 4 }}>
+      <Typography variant="h2" sx={{ m: 4 }}>
         {t('UnauthorizedError.unauthorizedMessage')}
       </Typography>
       <Button variant="contained" onClick={() => router.push('/')}>

--- a/src/components/UserList/index.tsx
+++ b/src/components/UserList/index.tsx
@@ -67,9 +67,7 @@ export default function UserList({ lang, users }: Props) {
       }}
     >
       <Box sx={{ paddingBottom: '1rem' }}>
-        <Typography variant="h4" component="h2">
-          {t('EditUsers.label')}
-        </Typography>
+        <Typography variant="h2">{t('EditUsers.label')}</Typography>
       </Box>
 
       <TableContainer>


### PR DESCRIPTION
Changes MUI typography header sizes to theme. Now H1 can be used directly without specifying separately variant and component type.

Also swaps the used headers across components etc. Everything should look the same.