### PR TITLE
Add back to top toggle

### DIFF
--- a/cypress/e2e/backToTopToggle.cy.ts
+++ b/cypress/e2e/backToTopToggle.cy.ts
@@ -1,0 +1,45 @@
+describe('BackToTopToggle button', () => {
+  const course = {
+    name: 'Kubernetes Fundamentals part 2',
+    header: 'Learn Kubernetes',
+    description:
+      'Take your first steps in using Kubernetes for container orchestration. This course will introduce you to the basic concepts and building blocks of Kubernetes and the architecture of the system. Get ready to start you cloud native journey!',
+    startDate: '2030-06-01T08:30',
+    endDate: '2030-07-01T08:30',
+    maxStudents: '100',
+  };
+
+  it('does not initially show backToTopToggle component', () => {
+    cy.login('testuser@test.com', 'TRAINER');
+    cy.getCy('backToTopToggle').should('not.be.visible');
+  });
+
+  it('shows the button after scrolling down and scrolls back to top when clicked', () => {
+    cy.login('testuser@test.com', 'TRAINER');
+    cy.visit('/course/create');
+    // create new course to fill course view further and enable scrolling down
+    cy.getCy('courseFormName').type(course.name);
+    cy.getCy('textEditorTextSelect').click();
+    cy.getCy('textSelectorHeader1').click();
+    cy.get('.ProseMirror').type(`${course.header}{enter}`);
+
+    cy.getCy('textEditorTextSelect').click();
+    cy.getCy('textSelectorParagraph').click();
+    cy.get('.ProseMirror').type(course.description);
+
+    cy.getCy('courseFormStartDate').type(course.startDate);
+    cy.getCy('courseFormEndDate').type(course.endDate);
+    cy.getCy('courseFormMaxStudents').clear().type(course.maxStudents);
+    cy.getCy('courseFormSubmit').click();
+    // view at top, button should not be visible
+    cy.getCy('backToTopToggle').should('not.be.visible');
+    // scroll to bottom to make toggle visible
+    cy.scrollTo('bottom');
+    cy.getCy('backToTopToggle').should('be.visible');
+    // scrolls to top by clicking button
+    cy.getCy('backToTopToggle').click();
+    cy.window().its('scrollY').should('eq', 0);
+    // view at top again, button should not be visible
+    cy.getCy('backToTopToggle').should('not.be.visible');
+  });
+});

--- a/src/app/[lang]/page.tsx
+++ b/src/app/[lang]/page.tsx
@@ -8,6 +8,7 @@ import BackgroundContainer from '@/components/BackgroundContainer';
 import SpeedDialMenu from '@/components/SpeedDialMenu';
 import SearchMenu from '@/components/SearchMenu';
 import { isTrainerOrAdmin } from '@/lib/auth-utils';
+import BackToTopToggle from '@/components/BackToTopToggle';
 
 export const dynamic = 'force-dynamic';
 
@@ -59,6 +60,7 @@ export default async function HomePage({ searchParams, params }: Props) {
           endDate: searchParams.endDate,
         }}
       />
+      <BackToTopToggle />
     </BackgroundContainer>
   );
 }

--- a/src/components/BackToTopToggle/index.tsx
+++ b/src/components/BackToTopToggle/index.tsx
@@ -28,6 +28,7 @@ export default function BackToTopToggle() {
   return (
     <Zoom in={showButton} timeout={200}>
       <Fab
+        data-testid="backToTopToggle"
         size="small"
         variant="circular"
         onClick={handleScrollToTop}

--- a/src/components/BackToTopToggle/index.tsx
+++ b/src/components/BackToTopToggle/index.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { Fab, Zoom } from '@mui/material';
+import KeyboardDoubleArrowUpIcon from '@mui/icons-material/KeyboardDoubleArrowUp';
+
+export default function BackToTopToggle() {
+  const [showButton, setShowButton] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const isScrolled = window.scrollY > 100;
+      setShowButton(isScrolled);
+    };
+    window.addEventListener('scroll', handleScroll);
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, []);
+
+  const handleScrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    });
+  };
+
+  return (
+    <Zoom in={showButton} timeout={200}>
+      <Fab
+        size="small"
+        variant="circular"
+        onClick={handleScrollToTop}
+        style={{
+          position: 'fixed',
+          display: 'flex',
+          justifyContent: 'center',
+          bottom: '1em',
+          opacity: '0.7',
+        }}
+      >
+        <KeyboardDoubleArrowUpIcon />
+      </Fab>
+    </Zoom>
+  );
+}


### PR DESCRIPTION
Adds back to top toggle button at the bottom of the main course view.

Visible on both desktop / mobile,, however only after the screen has been scrolled down somewhat (set currently at 100px).