### PR TITLE
Fix user listing pagination

### DIFF
--- a/src/components/UserList/index.tsx
+++ b/src/components/UserList/index.tsx
@@ -126,7 +126,14 @@ export default function UserList({ lang, users }: Props) {
   }
 
   function handleChangeVisibleRows(event: React.ChangeEvent<HTMLInputElement>) {
-    setVisibleRowsPerPage(Number(event.target.value));
+    const newRowsPerPage = Number(event.target.value);
+    const newPage = Math.min(
+      page,
+      Math.ceil(filteredUsers.length / newRowsPerPage) - 1
+    );
+
+    setPage(newPage);
+    setVisibleRowsPerPage(newRowsPerPage);
   }
 
   async function handleUserRoleChange(userId: string, newRole: $Enums.Role) {


### PR DESCRIPTION
Modifies the function that handles the row change. 

Steps to reproduce the bug (assumed here that the db is seeded with enough users - here used the batch from seed file):
1) Open admin page.
2) With 5 rows visible go to page 2
3) Set to display 25 rows

Result:

![image](https://github.com/ohtutraininghub/traininghub/assets/39833064/a90e5b98-0944-43fe-a5e0-04134e71c5df)

Messes up the the pagination and shows a long empty table. Stuck there until rows is switched.
