### PR TITLE
#294/feat/authenticate trainer id when deleting course

### DIFF
--- a/src/lib/auth-utils.ts
+++ b/src/lib/auth-utils.ts
@@ -1,4 +1,4 @@
-import { Role, User as PrismaUser } from '@prisma/client';
+import { Role, User as PrismaUser, Course } from '@prisma/client';
 
 type User = Omit<PrismaUser, 'emailVerified'>;
 
@@ -11,3 +11,6 @@ export const isTrainer = (user: User) => user.role === Role.TRAINER;
 
 export const hasCourseEditRights = (user: User) =>
   isAdmin(user) || isTrainer(user);
+
+export const hasCourseDeleteRights = (user: User, course: Course) =>
+  user.id === course.createdById;


### PR DESCRIPTION
API call now checks that the current user has the required permissions to be deleting the course attempting to be deleted.

Also added a utility function to /lib/auth-utils.ts to check if user has course deletion permissions.