### PR TITLE
Fix type errors in Jest test files.

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,6 @@
     "strict": true,
     "target": "es5"
   },
-  "exclude": ["node_modules"],
+  "exclude": ["node_modules", "./cypress.config.ts", "cypress", "**/*.cy.tsx"],
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"]
 }


### PR DESCRIPTION
Test files had unnecessary error highlights due to Jest and Cypress conflict. 