### PR TITLE
342/feat/admins have permission to delete any template

### DIFF
--- a/src/app/api/template/route.test.ts
+++ b/src/app/api/template/route.test.ts
@@ -5,6 +5,7 @@ import { NextRequest } from 'next/server';
 import { createMocks } from 'node-mocks-http';
 import { Role } from '@prisma/client';
 import { getServerAuthSession } from '@/lib/auth';
+import { NOTFOUND } from 'dns';
 
 const adminUser = {
   id: 'clo079ls3000108jsbdbsc8pv',
@@ -205,7 +206,7 @@ describe('Template API tests', () => {
       expect(response.status).toBe(StatusCodeType.OK);
     });
 
-    it('Fails when deleting template created by another user', async () => {
+    it('Fails when trainer tries to delete template created by another user', async () => {
       (getServerAuthSession as jest.Mock).mockImplementation(async () =>
         Promise.resolve({
           user: trainerUser1,
@@ -227,7 +228,32 @@ describe('Template API tests', () => {
 
       expect(data.message).toContain('Forbidden');
       expect(data.messageType).toBe(MessageType.ERROR);
-      expect(response.status).toBe(403);
+      expect(response.status).toBe(StatusCodeType.FORBIDDEN);
+    });
+
+    it('Succeeds when admin tries to delete template created by another user', async () => {
+      (getServerAuthSession as jest.Mock).mockImplementation(async () =>
+        Promise.resolve({
+          user: adminUser,
+        })
+      );
+      await prisma.template.create({
+        data: {
+          ...newTemplateByTrainer2,
+          tags: {
+            connect: [],
+          },
+        },
+      });
+
+      const templateInDb = await prisma.template.findFirst();
+      const req = mockDeleteRequest({ templateId: templateInDb?.id });
+      const response = await DELETE(req);
+      const data = await response.json();
+
+      expect(data.message).toContain('Template successfully deleted');
+      expect(data.messageType).toBe(MessageType.SUCCESS);
+      expect(response.status).toBe(StatusCodeType.OK);
     });
 
     it('Fails when trying to delete nonexistent template', async () => {
@@ -244,7 +270,7 @@ describe('Template API tests', () => {
 
       expect(data.message).toContain('Template by given id was not found');
       expect(data.messageType).toBe(MessageType.ERROR);
-      expect(response.status).toBe(404);
+      expect(response.status).toBe(StatusCodeType.NOT_FOUND);
     });
   });
 });

--- a/src/app/api/template/route.test.ts
+++ b/src/app/api/template/route.test.ts
@@ -5,7 +5,6 @@ import { NextRequest } from 'next/server';
 import { createMocks } from 'node-mocks-http';
 import { Role } from '@prisma/client';
 import { getServerAuthSession } from '@/lib/auth';
-import { NOTFOUND } from 'dns';
 
 const adminUser = {
   id: 'clo079ls3000108jsbdbsc8pv',

--- a/src/lib/auth-utils.ts
+++ b/src/lib/auth-utils.ts
@@ -18,4 +18,4 @@ export const hasCourseDeleteRights = (user: User, course: Course) =>
 export const hasTemplateDeleteRights = (
   user: User,
   template: { createdById: string }
-) => user.id === template.createdById;
+) => user.id === template.createdById || isAdmin(user);


### PR DESCRIPTION
Added simple extra check for the user being an admin to the auth-utils.ts hasTemplateDeleteRights function

Tests check that the api allows an admin to delete another user's template