### PR TITLE
#348/feat/create and add template form to modal

### DIFF
--- a/src/app/[lang]/locales/en/app.json
+++ b/src/app/[lang]/locales/en/app.json
@@ -11,7 +11,8 @@
     "startDate": "Start date",
     "submit": "Submit",
     "summary": "Summary (optional)",
-    "tags": "Tags"
+    "tags": "Tags",
+    "update": "Update"
   },
   "Error": {
     "somethingWrong": "Something went wrong... Try again"

--- a/src/app/[lang]/locales/en/app.json
+++ b/src/app/[lang]/locales/en/app.json
@@ -33,6 +33,7 @@
     "courseDescription": "The course description is visible to all users upon opening the course details page. Utilize the online text editor for formatting. Hover over buttons for tooltips on each functionality.",
     "createCourse": "This form is used to create a new course. Fill in the necessary details, and once you're done, click the 'Submit' button at the bottom to publish the course. Some fields are optional. See the tooltips for details.",
     "editCourse": "This form allows you to modify the course details. After making the desired updates, remember to save the changes by clicking the 'Update' button at the bottom. Your modifications will be published instantly.",
+    "editTemplate": "This form allows you to modify the template details. After making the desired updates, remember to save the changes by clicking the 'Update' button at the bottom. Your modifications will be published instantly.",
     "endDate": "The end date signifies the completion of the course. This is a mandatory field. Courses are displayed in the course listings for all users until their end date.",
     "image": "Main image for the course. An image can be added by entering a valid URL for the image. The image will be shown both on the main view, and on an opened course details page.",
     "lastCancelDate": "Last date to cancel enrollment is an optional field. If specified, it denotes the final date for students to cancel their enrollment in the course.",

--- a/src/app/[lang]/locales/en/app.json
+++ b/src/app/[lang]/locales/en/app.json
@@ -11,8 +11,7 @@
     "startDate": "Start date",
     "submit": "Submit",
     "summary": "Summary (optional)",
-    "tags": "Tags",
-    "update": "Update"
+    "tags": "Tags"
   },
   "Error": {
     "somethingWrong": "Something went wrong... Try again"
@@ -29,6 +28,10 @@
   },
   "Template": {
     "selectTemplate": "Select template"
+  },
+  "TemplateForm": {
+    "title": "Edit Template Details",
+    "update": "Update"
   },
   "Tooltip": {
     "courseDescription": "The course description is visible to all users upon opening the course details page. Utilize the online text editor for formatting. Hover over buttons for tooltips on each functionality.",

--- a/src/app/[lang]/locales/en/components.json
+++ b/src/app/[lang]/locales/en/components.json
@@ -82,7 +82,7 @@
     "button": {
       "edit": "Edit",
       "message": "Form here",
-      "submit": "Submit"
+      "update": "Update"
     },
     "confirmEdit": "Are you sure you want to edit this template?"
   },

--- a/src/app/[lang]/locales/en/components.json
+++ b/src/app/[lang]/locales/en/components.json
@@ -78,10 +78,13 @@
   "EditButton": {
     "editCourse": "Edit"
   },
-  "EditTemplateButton": {
+  "EditTemplate": {
     "button": {
-      "edit": "Edit"
-    }
+      "edit": "Edit",
+      "message": "Form here",
+      "submit": "Submit"
+    },
+    "confirmEdit": "Are you sure you want to edit this template?"
   },
   "EnrollButton": {
     "confirmEnroll": "Confirm enroll?",

--- a/src/app/[lang]/locales/en/components.json
+++ b/src/app/[lang]/locales/en/components.json
@@ -80,8 +80,7 @@
   },
   "EditTemplate": {
     "button": {
-      "edit": "Edit",
-      "update": "Update"
+      "edit": "Edit"
     },
     "confirmEdit": "Are you sure you want to edit this template?"
   },

--- a/src/app/[lang]/locales/en/components.json
+++ b/src/app/[lang]/locales/en/components.json
@@ -81,7 +81,6 @@
   "EditTemplate": {
     "button": {
       "edit": "Edit",
-      "message": "Form here",
       "update": "Update"
     },
     "confirmEdit": "Are you sure you want to edit this template?"

--- a/src/app/[lang]/profile/page.tsx
+++ b/src/app/[lang]/profile/page.tsx
@@ -92,6 +92,7 @@ export default async function ProfilePage({ searchParams, params }: Props) {
         courses={userData?.courses ?? []}
         users={allUsers}
         templates={templates}
+        tags={tags}
       >
         <CreateTag
           tagsHeader={t('admin:TagsSection.header')}

--- a/src/components/CourseTemplateModal/EditTemplateForm.test.tsx
+++ b/src/components/CourseTemplateModal/EditTemplateForm.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import { EditTemplateForm } from './EditTemplateForm';
 import { renderWithTheme } from '@/lib/test-utils';
 

--- a/src/components/CourseTemplateModal/EditTemplateForm.test.tsx
+++ b/src/components/CourseTemplateModal/EditTemplateForm.test.tsx
@@ -73,6 +73,6 @@ describe('EditTemplateForm', () => {
 
     // Assert that the update button is rendered correctly
     expect(buttonElement).toBeInTheDocument();
-    expect(buttonElement).toHaveTextContent('EditTemplate.button.update');
+    expect(buttonElement).toHaveTextContent('CourseForm.update');
   });
 });

--- a/src/components/CourseTemplateModal/EditTemplateForm.test.tsx
+++ b/src/components/CourseTemplateModal/EditTemplateForm.test.tsx
@@ -45,6 +45,7 @@ describe('EditTemplateForm', () => {
       />
     );
     // Find the labels by their associated text
+    const formTitle = screen.getByText(/TemplateForm\.title/i);
     const nameLabel = screen.getByText(/CourseForm\.name/i);
     const descriptionLabel = screen.getByText(/CourseForm\.description/i);
     const summaryLabel = screen.getByText(/CourseForm\.summary/i);
@@ -52,6 +53,7 @@ describe('EditTemplateForm', () => {
     const tagsLabel = screen.getByText(/CourseForm\.tags/i);
     const maxStudentsLabel = screen.getByText(/CourseForm\.maxStudents/i);
     // Assert that the names are rendered correctly
+    expect(formTitle).toHaveTextContent('TemplateForm.title');
     expect(nameLabel).toHaveTextContent('CourseForm.name');
     expect(descriptionLabel).toHaveTextContent('CourseForm.description');
     expect(summaryLabel).toHaveTextContent('CourseForm.summary');
@@ -73,6 +75,6 @@ describe('EditTemplateForm', () => {
 
     // Assert that the update button is rendered correctly
     expect(buttonElement).toBeInTheDocument();
-    expect(buttonElement).toHaveTextContent('CourseForm.update');
+    expect(buttonElement).toHaveTextContent('TemplateForm.update');
   });
 });

--- a/src/components/CourseTemplateModal/EditTemplateForm.test.tsx
+++ b/src/components/CourseTemplateModal/EditTemplateForm.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { EditTemplateForm } from './EditTemplateForm';
+import { renderWithTheme } from '@/lib/test-utils';
+
+jest.mock('../../lib/i18n/client', () => ({
+  // this mock makes sure any components using the translate hook can use it without a warning being shown
+  useTranslation: () => {
+    return {
+      t: (str: string) => str,
+      i18n: {
+        changeLanguage: () => new Promise(() => {}),
+      },
+    };
+  },
+}));
+
+describe('EditTemplateForm', () => {
+  it('renders the input sections to the form', () => {
+    renderWithTheme(
+      <EditTemplateForm
+        templateId="templateId"
+        updateTemplate={() => {}}
+        tags={[]}
+        lang="en"
+      />
+    );
+    const name = screen.getByTestId('templateFormName');
+    const summary = screen.getByTestId('templateFormSummary');
+    const image = screen.getByTestId('templateFormImage');
+    const maxStudents = screen.getByTestId('templateFormMaxStudents');
+    // Assert that input elements of the form are rendered
+    expect(name).toBeInTheDocument();
+    expect(summary).toBeInTheDocument();
+    expect(image).toBeInTheDocument();
+    expect(maxStudents).toBeInTheDocument();
+  });
+
+  it('renders the form labels with correct text', () => {
+    renderWithTheme(
+      <EditTemplateForm
+        templateId="templateId"
+        updateTemplate={() => {}}
+        tags={[]}
+        lang="en"
+      />
+    );
+    // Find the labels by their associated text
+    const nameLabel = screen.getByText(/CourseForm\.name/i);
+    const descriptionLabel = screen.getByText(/CourseForm\.description/i);
+    const summaryLabel = screen.getByText(/CourseForm\.summary/i);
+    const imageLabel = screen.getByText(/CourseForm\.courseImage/i);
+    const tagsLabel = screen.getByText(/CourseForm\.tags/i);
+    const maxStudentsLabel = screen.getByText(/CourseForm\.maxStudents/i);
+    // Assert that the names are rendered correctly
+    expect(nameLabel).toBeInTheDocument();
+    expect(descriptionLabel).toBeInTheDocument();
+    expect(summaryLabel).toBeInTheDocument();
+    expect(imageLabel).toBeInTheDocument();
+    expect(tagsLabel).toBeInTheDocument();
+    expect(maxStudentsLabel).toBeInTheDocument();
+  });
+
+  it('renders the update button with the correct text', () => {
+    renderWithTheme(
+      <EditTemplateForm
+        templateId="templateId"
+        updateTemplate={() => {}}
+        tags={[]}
+        lang="en"
+      />
+    );
+    const buttonElement = screen.getByTestId('updateTemplateButton');
+
+    // Assert that the update button is rendered correctly
+    expect(buttonElement).toBeInTheDocument();
+    expect(buttonElement).toHaveTextContent('EditTemplate.button.update');
+  });
+});

--- a/src/components/CourseTemplateModal/EditTemplateForm.test.tsx
+++ b/src/components/CourseTemplateModal/EditTemplateForm.test.tsx
@@ -52,12 +52,12 @@ describe('EditTemplateForm', () => {
     const tagsLabel = screen.getByText(/CourseForm\.tags/i);
     const maxStudentsLabel = screen.getByText(/CourseForm\.maxStudents/i);
     // Assert that the names are rendered correctly
-    expect(nameLabel).toBeInTheDocument();
-    expect(descriptionLabel).toBeInTheDocument();
-    expect(summaryLabel).toBeInTheDocument();
-    expect(imageLabel).toBeInTheDocument();
-    expect(tagsLabel).toBeInTheDocument();
-    expect(maxStudentsLabel).toBeInTheDocument();
+    expect(nameLabel).toHaveTextContent('CourseForm.name');
+    expect(descriptionLabel).toHaveTextContent('CourseForm.description');
+    expect(summaryLabel).toHaveTextContent('CourseForm.summary');
+    expect(imageLabel).toHaveTextContent('CourseForm.courseImage');
+    expect(tagsLabel).toHaveTextContent('CourseForm.tags');
+    expect(maxStudentsLabel).toHaveTextContent('CourseForm.maxStudents');
   });
 
   it('renders the update button with the correct text', () => {

--- a/src/components/CourseTemplateModal/EditTemplateForm.tsx
+++ b/src/components/CourseTemplateModal/EditTemplateForm.tsx
@@ -47,7 +47,6 @@ export function EditTemplateForm({ lang, updateTemplate, tags }: Props) {
         textAlign="center"
         marginBottom={1}
       >
-        {/* Edit Template Details */}
         {t('TemplateForm.title')}
         <StyledTooltip lang={lang} title={t('Tooltip.editTemplate')} />
       </Typography>

--- a/src/components/CourseTemplateModal/EditTemplateForm.tsx
+++ b/src/components/CourseTemplateModal/EditTemplateForm.tsx
@@ -2,22 +2,32 @@
 
 import { DictProps } from '@i18n/index';
 import { useTranslation } from '@i18n/client';
-import { Button, InputLabel, Input } from '@mui/material';
+import {
+  Button,
+  InputLabel,
+  Input,
+  Select,
+  Box,
+  Chip,
+  MenuItem,
+} from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import { Controller, useForm } from 'react-hook-form';
 import { TemplateSchemaType } from '@/lib/zod/templates';
 import FormFieldError from '../FormFieldError';
 import StyledTooltip from '@/components/StyledTooltip';
 import RichTextEditor from '@/components/TextEditor';
+import { Tag } from '@prisma/client';
 
 interface Props extends DictProps {
   templateId: string;
   submitTemplate: () => void;
+  tags: Tag[];
 }
 
 type FormType = TemplateSchemaType;
 
-export function EditTemplateForm({ lang, submitTemplate }: Props) {
+export function EditTemplateForm({ lang, submitTemplate, tags }: Props) {
   const { t } = useTranslation(lang, 'components');
   const { palette } = useTheme();
   const {
@@ -105,6 +115,92 @@ export function EditTemplateForm({ lang, submitTemplate }: Props) {
             'data-testid': 'courseFormImage',
           }}
         />
+        <Controller
+          name="tags"
+          control={control}
+          defaultValue={[]}
+          render={({ field }) => {
+            return (
+              <>
+                <InputLabel htmlFor="tagSelection">
+                  {t('CourseForm.tags')}
+                  <StyledTooltip
+                    data-testid="tooltipTags"
+                    lang={lang}
+                    title={t('Tooltip.tags')}
+                  />
+                </InputLabel>
+                <Select
+                  {...field}
+                  id="tagSelection"
+                  color="secondary"
+                  multiple
+                  renderValue={(field) => (
+                    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+                      {field.map((tag, idx) => (
+                        <Chip
+                          key={idx}
+                          label={tag}
+                          variant="outlined"
+                          sx={{
+                            backgroundColor: palette.surface.light,
+                            borderColor: palette.black.light,
+                          }}
+                        />
+                      ))}
+                    </Box>
+                  )}
+                >
+                  {tags.map((tag) => (
+                    <MenuItem
+                      key={tag.id}
+                      value={tag.name}
+                      divider
+                      sx={{
+                        '&.Mui-selected': {
+                          backgroundColor: palette.surface.main,
+                        },
+                        '&.Mui-selected.Mui-focusVisible': {
+                          backgroundColor: palette.surface.dark,
+                        },
+                        '&:hover': {
+                          backgroundColor: palette.surface.light,
+                        },
+                        '&.Mui-selected:hover': {
+                          backgroundColor: palette.surface.main,
+                        },
+                      }}
+                    >
+                      {tag.name}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </>
+            );
+          }}
+        />
+        <InputLabel htmlFor="courseFormMaxStudents">
+          {t('CourseForm.maxStudents')}
+          <StyledTooltip
+            data-testid="maxStudents"
+            lang={lang}
+            title={t('Tooltip.maxStudents')}
+          />
+        </InputLabel>
+        <Input
+          {...register('maxStudents', {
+            setValueAs: (value) => Number(value),
+          })}
+          color="secondary"
+          id="courseFormMaxStudents"
+          type="number"
+          error={!!errors.maxStudents}
+          inputProps={{
+            min: 1,
+            'data-testid': 'courseFormMaxStudents',
+          }}
+        />
+        <FormFieldError error={errors.maxStudents} />
         <Button
           type="submit"
           variant="contained"

--- a/src/components/CourseTemplateModal/EditTemplateForm.tsx
+++ b/src/components/CourseTemplateModal/EditTemplateForm.tsx
@@ -10,6 +10,7 @@ import {
   Box,
   Chip,
   MenuItem,
+  Typography,
 } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import { Controller, useForm } from 'react-hook-form';
@@ -40,6 +41,15 @@ export function EditTemplateForm({ lang, submitTemplate, tags }: Props) {
 
   return (
     <>
+      <Typography
+        variant="h2"
+        color={palette.black.main}
+        textAlign="center"
+        marginBottom={1}
+      >
+        Edit Template Details
+        <StyledTooltip lang={lang} title={t('Tooltip.editTemplate')} />
+      </Typography>
       <form
         id="templateForm"
         style={{ display: 'flex', flexDirection: 'column', gap: 10 }}

--- a/src/components/CourseTemplateModal/EditTemplateForm.tsx
+++ b/src/components/CourseTemplateModal/EditTemplateForm.tsx
@@ -22,13 +22,13 @@ import { Tag } from '@prisma/client';
 
 interface Props extends DictProps {
   templateId: string;
-  submitTemplate: () => void;
+  updateTemplate: () => void;
   tags: Tag[];
 }
 
 type FormType = TemplateSchemaType;
 
-export function EditTemplateForm({ lang, submitTemplate, tags }: Props) {
+export function EditTemplateForm({ lang, updateTemplate, tags }: Props) {
   const { t } = useTranslation(lang, 'components');
   const { palette } = useTheme();
   const {
@@ -53,7 +53,7 @@ export function EditTemplateForm({ lang, submitTemplate, tags }: Props) {
       <form
         id="templateForm"
         style={{ display: 'flex', flexDirection: 'column', gap: 10 }}
-        onSubmit={submitTemplate}
+        onSubmit={updateTemplate}
       >
         <InputLabel htmlFor="courseFormName">{t('CourseForm.name')}</InputLabel>
         <Input
@@ -225,7 +225,7 @@ export function EditTemplateForm({ lang, submitTemplate, tags }: Props) {
             },
           }}
         >
-          {t('EditTemplate.button.submit')}
+          {t('EditTemplate.button.update')}
         </Button>
       </form>
     </>

--- a/src/components/CourseTemplateModal/EditTemplateForm.tsx
+++ b/src/components/CourseTemplateModal/EditTemplateForm.tsx
@@ -29,7 +29,7 @@ interface Props extends DictProps {
 type FormType = TemplateSchemaType;
 
 export function EditTemplateForm({ lang, updateTemplate, tags }: Props) {
-  const { t } = useTranslation(lang, 'components');
+  const { t } = useTranslation(lang);
   const { palette } = useTheme();
   const {
     control,

--- a/src/components/CourseTemplateModal/EditTemplateForm.tsx
+++ b/src/components/CourseTemplateModal/EditTemplateForm.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { DictProps } from '@i18n/index';
+import { useTranslation } from '@i18n/client';
+import { Button, InputLabel, Input } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+import { Controller, useForm } from 'react-hook-form';
+import { TemplateSchemaType } from '@/lib/zod/templates';
+import FormFieldError from '../FormFieldError';
+import StyledTooltip from '@/components/StyledTooltip';
+import RichTextEditor from '@/components/TextEditor';
+
+interface Props extends DictProps {
+  templateId: string;
+  submitTemplate: () => void;
+}
+
+type FormType = TemplateSchemaType;
+
+export function EditTemplateForm({ lang, submitTemplate }: Props) {
+  const { t } = useTranslation(lang, 'components');
+  const { palette } = useTheme();
+  const {
+    control,
+    register,
+    formState: { errors },
+  } = useForm<FormType>({
+    defaultValues: {},
+  });
+
+  return (
+    <>
+      <form
+        id="templateForm"
+        style={{ display: 'flex', flexDirection: 'column', gap: 10 }}
+        onSubmit={submitTemplate}
+      >
+        <InputLabel htmlFor="courseFormName">{t('CourseForm.name')}</InputLabel>
+        <Input
+          {...register('name')}
+          color="secondary"
+          id="courseFormName"
+          error={!!errors.name}
+          autoComplete="off"
+          inputProps={{
+            'data-testid': 'courseFormName',
+          }}
+        />
+        <FormFieldError error={errors.name} />
+
+        <InputLabel htmlFor="courseFormDescription">
+          {t('CourseForm.description')}
+          <StyledTooltip
+            testid="tooltipCourseDescription"
+            lang={lang}
+            title={t('Tooltip.courseDescription')}
+          />
+        </InputLabel>
+        <Controller
+          data-testid="courseFormDescription"
+          name="description"
+          control={control}
+          defaultValue=""
+          render={({ field: { onChange, value } }) => (
+            <RichTextEditor lang={lang} value={value} onChange={onChange} />
+          )}
+        />
+        <FormFieldError error={errors.description} />
+
+        <InputLabel htmlFor="courseFormSummary">
+          {t('CourseForm.summary')}
+          <StyledTooltip
+            testid="tooltipCourseSummary"
+            lang={lang}
+            title={t('Tooltip.summary')}
+          />
+        </InputLabel>
+        <Input
+          {...register('summary')}
+          color="secondary"
+          id="courseFormSummary"
+          error={!!errors.summary}
+          autoComplete="off"
+          inputProps={{
+            maxLength: 150,
+            'data-testid': 'courseFormSummary',
+          }}
+        />
+        <FormFieldError error={errors.summary} />
+
+        <InputLabel htmlFor="courseFormImage">
+          {t('CourseForm.courseImage')}
+          <StyledTooltip
+            testid="tooltipCourseImage"
+            lang={lang}
+            title={t('Tooltip.image')}
+          />
+        </InputLabel>
+        <Input
+          {...register('image')}
+          id="courseFormImage"
+          color="secondary"
+          error={!!errors.image}
+          inputProps={{
+            'data-testid': 'courseFormImage',
+          }}
+        />
+        <Button
+          type="submit"
+          variant="contained"
+          sx={{
+            display: 'block',
+            margin: 'auto',
+            mt: 2,
+            color: palette.white.main,
+            backgroundColor: palette.secondary.main,
+            '&:hover': {
+              backgroundColor: palette.secondary.light,
+            },
+          }}
+        >
+          {t('EditTemplate.button.submit')}
+        </Button>
+      </form>
+    </>
+  );
+}

--- a/src/components/CourseTemplateModal/EditTemplateForm.tsx
+++ b/src/components/CourseTemplateModal/EditTemplateForm.tsx
@@ -59,16 +59,16 @@ export function EditTemplateForm({ lang, updateTemplate, tags }: Props) {
         <Input
           {...register('name')}
           color="secondary"
-          id="courseFormName"
+          id="templateFormName"
           error={!!errors.name}
           autoComplete="off"
           inputProps={{
-            'data-testid': 'courseFormName',
+            'data-testid': 'templateFormName',
           }}
         />
         <FormFieldError error={errors.name} />
 
-        <InputLabel htmlFor="courseFormDescription">
+        <InputLabel>
           {t('CourseForm.description')}
           <StyledTooltip
             testid="tooltipCourseDescription"
@@ -77,7 +77,7 @@ export function EditTemplateForm({ lang, updateTemplate, tags }: Props) {
           />
         </InputLabel>
         <Controller
-          data-testid="courseFormDescription"
+          data-testid="templateFormDescription"
           name="description"
           control={control}
           defaultValue=""
@@ -90,7 +90,7 @@ export function EditTemplateForm({ lang, updateTemplate, tags }: Props) {
         <InputLabel htmlFor="courseFormSummary">
           {t('CourseForm.summary')}
           <StyledTooltip
-            testid="tooltipCourseSummary"
+            data-testid="tooltipCourseSummary"
             lang={lang}
             title={t('Tooltip.summary')}
           />
@@ -98,12 +98,12 @@ export function EditTemplateForm({ lang, updateTemplate, tags }: Props) {
         <Input
           {...register('summary')}
           color="secondary"
-          id="courseFormSummary"
+          id="templateFormSummary"
           error={!!errors.summary}
           autoComplete="off"
           inputProps={{
             maxLength: 150,
-            'data-testid': 'courseFormSummary',
+            'data-testid': 'templateFormSummary',
           }}
         />
         <FormFieldError error={errors.summary} />
@@ -111,18 +111,18 @@ export function EditTemplateForm({ lang, updateTemplate, tags }: Props) {
         <InputLabel htmlFor="courseFormImage">
           {t('CourseForm.courseImage')}
           <StyledTooltip
-            testid="tooltipCourseImage"
+            data-testid="tooltipCourseImage"
             lang={lang}
             title={t('Tooltip.image')}
           />
         </InputLabel>
         <Input
           {...register('image')}
-          id="courseFormImage"
+          id="templateFormImage"
           color="secondary"
           error={!!errors.image}
           inputProps={{
-            'data-testid': 'courseFormImage',
+            'data-testid': 'templateFormImage',
           }}
         />
         <Controller
@@ -192,7 +192,7 @@ export function EditTemplateForm({ lang, updateTemplate, tags }: Props) {
         <InputLabel htmlFor="courseFormMaxStudents">
           {t('CourseForm.maxStudents')}
           <StyledTooltip
-            data-testid="maxStudents"
+            data-testid="tooltipMaxStudents"
             lang={lang}
             title={t('Tooltip.maxStudents')}
           />
@@ -202,18 +202,19 @@ export function EditTemplateForm({ lang, updateTemplate, tags }: Props) {
             setValueAs: (value) => Number(value),
           })}
           color="secondary"
-          id="courseFormMaxStudents"
+          id="templateFormMaxStudents"
           type="number"
           error={!!errors.maxStudents}
           inputProps={{
             min: 1,
-            'data-testid': 'courseFormMaxStudents',
+            'data-testid': 'templateFormMaxStudents',
           }}
         />
         <FormFieldError error={errors.maxStudents} />
         <Button
           type="submit"
           variant="contained"
+          data-testid="updateTemplateButton"
           sx={{
             display: 'block',
             margin: 'auto',

--- a/src/components/CourseTemplateModal/EditTemplateForm.tsx
+++ b/src/components/CourseTemplateModal/EditTemplateForm.tsx
@@ -228,7 +228,7 @@ export function EditTemplateForm({ lang, updateTemplate, tags }: Props) {
             },
           }}
         >
-          {t('EditTemplate.button.update')}
+          {t('CourseForm.update')}
         </Button>
       </form>
     </>

--- a/src/components/CourseTemplateModal/EditTemplateForm.tsx
+++ b/src/components/CourseTemplateModal/EditTemplateForm.tsx
@@ -47,7 +47,8 @@ export function EditTemplateForm({ lang, updateTemplate, tags }: Props) {
         textAlign="center"
         marginBottom={1}
       >
-        Edit Template Details
+        {/* Edit Template Details */}
+        {t('TemplateForm.title')}
         <StyledTooltip lang={lang} title={t('Tooltip.editTemplate')} />
       </Typography>
       <form
@@ -228,7 +229,7 @@ export function EditTemplateForm({ lang, updateTemplate, tags }: Props) {
             },
           }}
         >
-          {t('CourseForm.update')}
+          {t('TemplateForm.update')}
         </Button>
       </form>
     </>

--- a/src/components/CourseTemplateModal/EditTemplateForm.tsx
+++ b/src/components/CourseTemplateModal/EditTemplateForm.tsx
@@ -55,7 +55,9 @@ export function EditTemplateForm({ lang, updateTemplate, tags }: Props) {
         style={{ display: 'flex', flexDirection: 'column', gap: 10 }}
         onSubmit={updateTemplate}
       >
-        <InputLabel htmlFor="courseFormName">{t('CourseForm.name')}</InputLabel>
+        <InputLabel htmlFor="templateFormName">
+          {t('CourseForm.name')}
+        </InputLabel>
         <Input
           {...register('name')}
           color="secondary"
@@ -68,7 +70,7 @@ export function EditTemplateForm({ lang, updateTemplate, tags }: Props) {
         />
         <FormFieldError error={errors.name} />
 
-        <InputLabel>
+        <InputLabel htmlFor="templateFormDescription">
           {t('CourseForm.description')}
           <StyledTooltip
             testid="tooltipCourseDescription"
@@ -87,7 +89,7 @@ export function EditTemplateForm({ lang, updateTemplate, tags }: Props) {
         />
         <FormFieldError error={errors.description} />
 
-        <InputLabel htmlFor="courseFormSummary">
+        <InputLabel htmlFor="templateFormSummary">
           {t('CourseForm.summary')}
           <StyledTooltip
             data-testid="tooltipCourseSummary"
@@ -108,7 +110,7 @@ export function EditTemplateForm({ lang, updateTemplate, tags }: Props) {
         />
         <FormFieldError error={errors.summary} />
 
-        <InputLabel htmlFor="courseFormImage">
+        <InputLabel htmlFor="templateFormImage">
           {t('CourseForm.courseImage')}
           <StyledTooltip
             data-testid="tooltipCourseImage"
@@ -189,7 +191,7 @@ export function EditTemplateForm({ lang, updateTemplate, tags }: Props) {
             );
           }}
         />
-        <InputLabel htmlFor="courseFormMaxStudents">
+        <InputLabel htmlFor="templateFormMaxStudents">
           {t('CourseForm.maxStudents')}
           <StyledTooltip
             data-testid="tooltipMaxStudents"

--- a/src/components/CourseTemplateModal/index.test.tsx
+++ b/src/components/CourseTemplateModal/index.test.tsx
@@ -1,19 +1,41 @@
-import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
 import CourseTemplateModal from '../CourseTemplateModal';
+import { renderWithTheme } from '@/lib/test-utils';
+
+jest.mock('../../lib/i18n/client', () => ({
+  // this mock makes sure any components using the translate hook can use it without a warning being shown
+  useTranslation: () => {
+    return {
+      t: (str: string) => str,
+      i18n: {
+        changeLanguage: () => new Promise(() => {}),
+      },
+    };
+  },
+}));
 
 describe('CourseTemplateModal', () => {
-  it('renders with a templateId', () => {
-    const templateId = '1';
+  it('closes modal when close button is clicked', () => {
+    // Mock onClose function
+    const onCloseMock = jest.fn();
 
-    render(
+    // Render the modal
+    const { getByTestId } = renderWithTheme(
       <CourseTemplateModal
-        templateId={templateId}
+        lang="en"
+        templateId="template_id"
         open={true}
-        onClose={() => {}}
+        onClose={onCloseMock}
+        tags={[]}
       />
     );
 
-    const element = screen.getByText('Template ID: 1');
-    expect(element).toBeInTheDocument();
+    // Find close button and click it
+    const closeButton = getByTestId('closeButton');
+    fireEvent.click(closeButton);
+
+    // Check if onClose function is called
+    expect(onCloseMock).toHaveBeenCalled();
   });
 });

--- a/src/components/CourseTemplateModal/index.tsx
+++ b/src/components/CourseTemplateModal/index.tsx
@@ -4,21 +4,29 @@ import React from 'react';
 import Modal from '@mui/material/Modal';
 import { Typography } from '@mui/material';
 import Card from '@mui/material/Card';
+import { DictProps } from '@/lib/i18n';
+import { EditTemplateForm } from './EditTemplateForm';
+import { useTheme } from '@mui/material/styles';
 
-interface CourseTemplateModalProps {
+interface CourseTemplateModalProps extends DictProps {
   templateId: string;
   open: boolean;
   onClose: () => void;
 }
 
 export default function CourseTemplateModal({
+  lang,
   templateId,
   onClose,
 }: CourseTemplateModalProps) {
+  const { palette } = useTheme();
   const handleClick = (event: object, reason: string) => {
     if (reason === 'backdropClick' || reason === 'escapeKeyDown') {
       onClose();
     }
+  };
+  const submitTemplate = () => {
+    onClose();
   };
 
   return (
@@ -34,6 +42,7 @@ export default function CourseTemplateModal({
           },
         }}
         sx={{
+          zIndex: 1200,
           display: 'flex',
           justifyContent: 'center',
           alignItems: 'center',
@@ -41,28 +50,34 @@ export default function CourseTemplateModal({
       >
         <Card
           sx={{
+            p: 4,
+            mb: 4,
+            borderRadius: 2,
+            backgroundColor: palette.surface.main,
+            boxShadow: 8,
             position: 'relative',
             display: 'flex',
             flexDirection: 'column',
             width: '1000px',
-            height: '900px',
             maxWidth: '100%',
             maxHeight: '100%',
             overflow: 'auto',
             overflowWrap: 'break-word',
-            borderRadius: '10px',
-            m: 2,
-            p: 3,
-            color: 'white.main',
-            backgroundColor: 'secondary.main',
-            textAlign: 'center',
-            outline: 0,
           }}
         >
-          {/* The following is just test text */}
-          <Typography variant="h1" sx={{ textAlign: 'center' }}>
-            Template ID: {templateId}
+          <Typography
+            variant="h2"
+            color={palette.black.main}
+            textAlign="center"
+            marginBottom={1}
+          >
+            Edit Template Details
           </Typography>
+          <EditTemplateForm
+            templateId={templateId}
+            lang={lang}
+            submitTemplate={submitTemplate}
+          />
         </Card>
       </Modal>
     </div>

--- a/src/components/CourseTemplateModal/index.tsx
+++ b/src/components/CourseTemplateModal/index.tsx
@@ -29,7 +29,7 @@ export default function CourseTemplateModal({
       onClose();
     }
   };
-  const submitTemplate = () => {
+  const updateTemplate = () => {
     onClose();
   };
 
@@ -85,7 +85,7 @@ export default function CourseTemplateModal({
             tags={tags}
             templateId={templateId}
             lang={lang}
-            submitTemplate={submitTemplate}
+            updateTemplate={updateTemplate}
           />
         </Card>
       </Modal>

--- a/src/components/CourseTemplateModal/index.tsx
+++ b/src/components/CourseTemplateModal/index.tsx
@@ -77,7 +77,7 @@ export default function CourseTemplateModal({
               padding: 1,
             }}
           >
-            <IconButton onClick={onClose}>
+            <IconButton onClick={onClose} data-testid={'closeButton'}>
               <CloseIcon sx={{ fontSize: '25px' }} />
             </IconButton>
           </Box>

--- a/src/components/CourseTemplateModal/index.tsx
+++ b/src/components/CourseTemplateModal/index.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import Modal from '@mui/material/Modal';
-import { Box, IconButton, Typography } from '@mui/material';
+import { Box, IconButton } from '@mui/material';
 import Card from '@mui/material/Card';
 import { DictProps } from '@/lib/i18n';
 import { EditTemplateForm } from './EditTemplateForm';
@@ -81,14 +81,6 @@ export default function CourseTemplateModal({
               <CloseIcon sx={{ fontSize: '25px' }} />
             </IconButton>
           </Box>
-          <Typography
-            variant="h2"
-            color={palette.black.main}
-            textAlign="center"
-            marginBottom={1}
-          >
-            Edit Template Details
-          </Typography>
           <EditTemplateForm
             tags={tags}
             templateId={templateId}

--- a/src/components/CourseTemplateModal/index.tsx
+++ b/src/components/CourseTemplateModal/index.tsx
@@ -8,17 +8,20 @@ import { DictProps } from '@/lib/i18n';
 import { EditTemplateForm } from './EditTemplateForm';
 import { useTheme } from '@mui/material/styles';
 import CloseIcon from '@mui/icons-material/Close';
+import { Tag } from '@prisma/client';
 
 interface CourseTemplateModalProps extends DictProps {
   templateId: string;
   open: boolean;
   onClose: () => void;
+  tags: Tag[];
 }
 
 export default function CourseTemplateModal({
   lang,
   templateId,
   onClose,
+  tags,
 }: CourseTemplateModalProps) {
   const { palette } = useTheme();
   const handleClick = (event: object, reason: string) => {
@@ -87,6 +90,7 @@ export default function CourseTemplateModal({
             Edit Template Details
           </Typography>
           <EditTemplateForm
+            tags={tags}
             templateId={templateId}
             lang={lang}
             submitTemplate={submitTemplate}

--- a/src/components/CourseTemplateModal/index.tsx
+++ b/src/components/CourseTemplateModal/index.tsx
@@ -2,11 +2,12 @@
 
 import React from 'react';
 import Modal from '@mui/material/Modal';
-import { Typography } from '@mui/material';
+import { Box, IconButton, Typography } from '@mui/material';
 import Card from '@mui/material/Card';
 import { DictProps } from '@/lib/i18n';
 import { EditTemplateForm } from './EditTemplateForm';
 import { useTheme } from '@mui/material/styles';
+import CloseIcon from '@mui/icons-material/Close';
 
 interface CourseTemplateModalProps extends DictProps {
   templateId: string;
@@ -65,6 +66,18 @@ export default function CourseTemplateModal({
             overflowWrap: 'break-word',
           }}
         >
+          <Box
+            sx={{
+              position: 'absolute',
+              top: 8,
+              right: 8,
+              padding: 1,
+            }}
+          >
+            <IconButton onClick={onClose}>
+              <CloseIcon sx={{ fontSize: '25px' }} />
+            </IconButton>
+          </Box>
           <Typography
             variant="h2"
             color={palette.black.main}

--- a/src/components/EditTemplate/EditTemplateButton.test.tsx
+++ b/src/components/EditTemplate/EditTemplateButton.test.tsx
@@ -42,7 +42,7 @@ describe('EditTemplateButton', () => {
     );
     const buttonElement = screen.getByTestId('EditTemplateButton');
     expect(buttonElement).toBeInTheDocument();
-    expect(buttonElement).toHaveTextContent('EditTemplateButton.button.edit');
+    expect(buttonElement).toHaveTextContent('EditTemplate.button.edit');
   });
 
   test('calls the onClick function when clicked', () => {

--- a/src/components/EditTemplate/EditTemplateButton.tsx
+++ b/src/components/EditTemplate/EditTemplateButton.tsx
@@ -34,7 +34,7 @@ export function EditTemplateButton({ lang, onClick }: EditTemplateButtonProps) {
         data-testid="EditTemplateButton"
       >
         <EditIcon sx={{ mr: isSmallScreen ? 0 : 1, fontSize: '22px' }} />
-        {!isSmallScreen && t('EditTemplateButton.button.edit')}
+        {!isSmallScreen && t('EditTemplate.button.edit')}
       </Button>
     </Box>
   );

--- a/src/components/ProfileView/ProfileTemplateList.test.tsx
+++ b/src/components/ProfileView/ProfileTemplateList.test.tsx
@@ -56,6 +56,7 @@ describe('ProfileTemplateList component', () => {
         headerText="Templates"
         templates={testTemplates}
         open={true}
+        tags={[]}
       />
     );
     const headerText = screen.getByTestId('templateListHeader');
@@ -66,7 +67,12 @@ describe('ProfileTemplateList component', () => {
 
   it('displays a message if the templates list is empty', () => {
     renderWithTheme(
-      <ProfileTemplateList headerText="Templates" templates={[]} open={true} />
+      <ProfileTemplateList
+        headerText="Templates"
+        templates={[]}
+        open={true}
+        tags={[]}
+      />
     );
     const noTemplatesText = screen.getByText('No templates to show.');
     expect(noTemplatesText).toBeInTheDocument();
@@ -78,6 +84,7 @@ describe('ProfileTemplateList component', () => {
         headerText="Templates"
         templates={testTemplates}
         open={true}
+        tags={[]}
       />
     );
     testTemplates.forEach((template) => {
@@ -91,6 +98,7 @@ describe('ProfileTemplateList component', () => {
         headerText="Templates"
         templates={testTemplates}
         open={false}
+        tags={[]}
       />
     );
     testTemplates.forEach((template) => {
@@ -104,6 +112,7 @@ describe('ProfileTemplateList component', () => {
         headerText="Templates"
         templates={testTemplates}
         open={false}
+        tags={[]}
       />
     );
     expect(screen.getByText('(2)', { exact: false })).toBeInTheDocument();
@@ -115,6 +124,7 @@ describe('ProfileTemplateList component', () => {
         headerText="Templates"
         templates={testTemplates}
         open={false}
+        tags={[]}
       />
     );
     const controlButton = screen.getByTestId('templateListControls');
@@ -133,6 +143,7 @@ describe('ProfileTemplateList component', () => {
         headerText="Templates"
         templates={testTemplates}
         open={false}
+        tags={[]}
       />
     );
     const controlButton = screen.getByTestId('templateListControls');
@@ -152,6 +163,7 @@ describe('ProfileTemplateList component', () => {
         headerText="Templates"
         templates={testTemplates}
         open={false}
+        tags={[]}
       />
     );
     const controlButton = screen.getByTestId('templateListControls');
@@ -171,6 +183,7 @@ describe('ProfileTemplateList component', () => {
         headerText="Templates"
         templates={testTemplates}
         open={false}
+        tags={[]}
       />
     );
     const controlButton = screen.getByTestId('templateListControls');
@@ -190,6 +203,7 @@ describe('ProfileTemplateList component', () => {
         headerText="Templates"
         templates={testTemplates}
         open={false}
+        tags={[]}
       />
     );
     const controlButton = screen.getByTestId('templateListControls');
@@ -208,6 +222,7 @@ describe('ProfileTemplateList component', () => {
         headerText="Templates"
         templates={testTemplates}
         open={false}
+        tags={[]}
       />
     );
     const controlButton = screen.getByTestId('templateListControls');
@@ -231,6 +246,7 @@ describe('ProfileTemplateList component', () => {
         headerText="Templates"
         templates={testTemplates}
         open={true}
+        tags={[]}
       />
     );
     const controlButton = screen.getByTestId('templateListControls');

--- a/src/components/ProfileView/ProfileTemplateList.tsx
+++ b/src/components/ProfileView/ProfileTemplateList.tsx
@@ -45,13 +45,11 @@ export default function ProfileTemplateList({
   const lang: Locale = i18n.defaultLocale;
 
   const handleEditButtonClick = (templateId: string) => {
-    console.log('handleEditButtonClick');
     setSelectedTemplate(templateId);
     setIsTemplateModalOpen(true);
   };
 
   const handleCloseTemplateModal = () => {
-    console.log('handleCloseTemplateModal');
     setIsTemplateModalOpen(false);
     setSelectedTemplate(null);
   };

--- a/src/components/ProfileView/ProfileTemplateList.tsx
+++ b/src/components/ProfileView/ProfileTemplateList.tsx
@@ -5,7 +5,7 @@ import { List } from '@mui/material';
 import { ListItem } from '@mui/material';
 import { ListItemText } from '@mui/material';
 import { Divider } from '@mui/material';
-import { Template } from '@prisma/client';
+import { Tag, Template } from '@prisma/client';
 import { useTheme } from '@mui/material/styles';
 import { Box, Tooltip, Typography } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
@@ -23,12 +23,14 @@ export interface ProfileCourseListProps {
   templates: Template[];
   open: boolean;
   timer?: boolean;
+  tags: Tag[];
 }
 
 export default function ProfileTemplateList({
   headerText,
   templates,
   open,
+  tags,
 }: ProfileCourseListProps) {
   const { palette } = useTheme();
   const [isCollapsed, setIsCollapsed] = useState(open);
@@ -141,6 +143,7 @@ export default function ProfileTemplateList({
       )}
       {isTemplateModalOpen && selectedTemplate && (
         <CourseTemplateModal
+          tags={tags}
           lang={lang}
           templateId={selectedTemplate}
           open={isTemplateModalOpen}

--- a/src/components/ProfileView/ProfileTemplateList.tsx
+++ b/src/components/ProfileView/ProfileTemplateList.tsx
@@ -42,11 +42,13 @@ export default function ProfileTemplateList({
   const lang: Locale = i18n.defaultLocale;
 
   const handleEditButtonClick = (templateId: string) => {
+    console.log('handleEditButtonClick');
     setSelectedTemplate(templateId);
     setIsTemplateModalOpen(true);
   };
 
   const handleCloseTemplateModal = () => {
+    console.log('handleCloseTemplateModal');
     setIsTemplateModalOpen(false);
     setSelectedTemplate(null);
   };
@@ -138,6 +140,7 @@ export default function ProfileTemplateList({
       )}
       {isTemplateModalOpen && selectedTemplate && (
         <CourseTemplateModal
+          lang={lang}
           templateId={selectedTemplate}
           open={isTemplateModalOpen}
           onClose={handleCloseTemplateModal}

--- a/src/components/ProfileView/index.tsx
+++ b/src/components/ProfileView/index.tsx
@@ -11,6 +11,7 @@ import { useTheme } from '@mui/material/styles';
 import { useSession } from 'next-auth/react';
 import UserList from '@/components/UserList';
 import { isTrainerOrAdmin } from '@/lib/auth-utils';
+import { Tag } from '@prisma/client';
 
 export interface userDetails {
   name: string;
@@ -19,6 +20,7 @@ export interface userDetails {
 }
 
 export interface ProfileViewProps extends PropsWithChildren {
+  tags: Tag[];
   userDetails: userDetails;
   courses: Course[];
   users: User[];
@@ -31,6 +33,7 @@ export default function ProfileView({
   users,
   children,
   templates,
+  tags,
 }: ProfileViewProps) {
   const [selectedTab, setSelectedTab] = useState(0);
   const { palette } = useTheme();
@@ -102,6 +105,7 @@ export default function ProfileView({
                   : 'My course templates'
               }
               templates={templates}
+              tags={tags}
               open={false}
             />
           )}

--- a/src/lib/zod/templates.ts
+++ b/src/lib/zod/templates.ts
@@ -25,3 +25,5 @@ export const templateDeleteSchema = z
     templateId: z.string().cuid(),
   })
   .strict();
+
+export type TemplateSchemaType = z.infer<typeof templateSchema>;


### PR DESCRIPTION
Created a UI part of a modal that can be used to update the template data.
The form has input fields similar to CourseForm but without the date and enrollment fields.
It has a close modal button and update button. Close modal button has a functionality but update button does not.