### PR TITLE
#349/feat/template edit form has template data when opened

### DIFF
--- a/src/components/CourseTemplateModal/EditTemplateForm.test.tsx
+++ b/src/components/CourseTemplateModal/EditTemplateForm.test.tsx
@@ -90,8 +90,9 @@ describe('EditTemplateForm Form Appearance Tests', () => {
 });
 
 describe('EditTemplateForm Autofill Tests', () => {
-  const template = {
-    id: '1234',
+  //Template data with all fields:
+  const allFields = {
+    id: '1',
     name: 'New course',
     description: 'A test course',
     summary: 'All you ever wanted to know about testing!',
@@ -100,10 +101,23 @@ describe('EditTemplateForm Autofill Tests', () => {
     createdById: '30',
     image: 'http://test-image.com',
   };
-  it('form autofills correct template data', () => {
+
+  //Template data with only required fields (name and description):
+  const onlyRequiredFields = {
+    id: '2',
+    name: 'New course',
+    description: 'A test course',
+    summary: null,
+    tags: [],
+    maxStudents: 10, //default value
+    createdById: '30',
+    image: null,
+  };
+
+  it('autofills correct values when template had all fields filled', () => {
     const { container } = renderWithTheme(
       <EditTemplateForm
-        templateData={template}
+        templateData={allFields}
         updateTemplate={() => {}}
         tags={[]}
         lang="en"
@@ -119,15 +133,64 @@ describe('EditTemplateForm Autofill Tests', () => {
     ) as HTMLInputElement;
     const image = screen.getByTestId('templateFormImage') as HTMLInputElement;
 
-    expect(name.value).toBe(template.name);
-    expect(description).toHaveTextContent(template.description);
-    expect(summary.value).toBe(template.summary);
-    expect(maxStudents.value).toBe(template.maxStudents.toString());
-    expect(image.value).toBe(template.image);
+    expect(name.value).toBe(allFields.name);
+    expect(description).toHaveTextContent(allFields.description);
+    expect(summary.value).toBe(allFields.summary);
+    expect(maxStudents.value).toBe(allFields.maxStudents.toString());
+    expect(image.value).toBe(allFields.image);
+  });
 
-    template.tags.forEach((tag) => {
+  it('autofills correct values when template had only required fields filled', () => {
+    const { container } = renderWithTheme(
+      <EditTemplateForm
+        templateData={onlyRequiredFields}
+        updateTemplate={() => {}}
+        tags={[]}
+        lang="en"
+      />
+    );
+    const name = screen.getByTestId('templateFormName') as HTMLInputElement;
+    const description = container.querySelector('.tiptap');
+    const summary = screen.getByTestId(
+      'templateFormSummary'
+    ) as HTMLInputElement;
+    const maxStudents = screen.getByTestId(
+      'templateFormMaxStudents'
+    ) as HTMLInputElement;
+    const image = screen.getByTestId('templateFormImage') as HTMLInputElement;
+
+    expect(name.value).toBe(onlyRequiredFields.name);
+    expect(description).toHaveTextContent(onlyRequiredFields.description);
+    expect(summary.value).toBe('');
+    expect(maxStudents.value).toBe(onlyRequiredFields.maxStudents.toString());
+    expect(image.value).toBe('');
+  });
+
+  it('autofills with tags', () => {
+    const { container } = renderWithTheme(
+      <EditTemplateForm
+        templateData={allFields}
+        updateTemplate={() => {}}
+        tags={[]}
+        lang="en"
+      />
+    );
+    allFields.tags.forEach((tag) => {
       const chip = screen.getByText(tag.name);
       expect(chip).toBeInTheDocument();
     });
+  });
+
+  it('autofills without tags', () => {
+    const { container } = renderWithTheme(
+      <EditTemplateForm
+        templateData={onlyRequiredFields}
+        updateTemplate={() => {}}
+        tags={[]}
+        lang="en"
+      />
+    );
+    const tags = container.querySelectorAll('.tag');
+    expect(tags).toHaveLength(0);
   });
 });

--- a/src/components/CourseTemplateModal/EditTemplateForm.test.tsx
+++ b/src/components/CourseTemplateModal/EditTemplateForm.test.tsx
@@ -14,11 +14,21 @@ jest.mock('../../lib/i18n/client', () => ({
   },
 }));
 
-describe('EditTemplateForm', () => {
+describe('EditTemplateForm Form Appearance Tests', () => {
+  const template = {
+    id: '',
+    name: '',
+    description: '',
+    summary: '',
+    tags: [],
+    maxStudents: 0,
+    createdById: '',
+    image: '',
+  };
   it('renders the input sections to the form', () => {
     renderWithTheme(
       <EditTemplateForm
-        templateId="templateId"
+        templateData={template}
         updateTemplate={() => {}}
         tags={[]}
         lang="en"
@@ -38,7 +48,7 @@ describe('EditTemplateForm', () => {
   it('renders the form labels with correct text', () => {
     renderWithTheme(
       <EditTemplateForm
-        templateId="templateId"
+        templateData={template}
         updateTemplate={() => {}}
         tags={[]}
         lang="en"
@@ -65,7 +75,7 @@ describe('EditTemplateForm', () => {
   it('renders the update button with the correct text', () => {
     renderWithTheme(
       <EditTemplateForm
-        templateId="templateId"
+        templateData={template}
         updateTemplate={() => {}}
         tags={[]}
         lang="en"
@@ -76,5 +86,48 @@ describe('EditTemplateForm', () => {
     // Assert that the update button is rendered correctly
     expect(buttonElement).toBeInTheDocument();
     expect(buttonElement).toHaveTextContent('TemplateForm.update');
+  });
+});
+
+describe('EditTemplateForm Autofill Tests', () => {
+  const template = {
+    id: '1234',
+    name: 'New course',
+    description: 'A test course',
+    summary: 'All you ever wanted to know about testing!',
+    tags: [{ id: '1', name: 'Testing' }],
+    maxStudents: 55,
+    createdById: '30',
+    image: 'http://test-image.com',
+  };
+  it('form autofills correct template data', () => {
+    const { container } = renderWithTheme(
+      <EditTemplateForm
+        templateData={template}
+        updateTemplate={() => {}}
+        tags={[]}
+        lang="en"
+      />
+    );
+    const name = screen.getByTestId('templateFormName') as HTMLInputElement;
+    const description = container.querySelector('.tiptap');
+    const summary = screen.getByTestId(
+      'templateFormSummary'
+    ) as HTMLInputElement;
+    const maxStudents = screen.getByTestId(
+      'templateFormMaxStudents'
+    ) as HTMLInputElement;
+    const image = screen.getByTestId('templateFormImage') as HTMLInputElement;
+
+    expect(name.value).toBe(template.name);
+    expect(description).toHaveTextContent(template.description);
+    expect(summary.value).toBe(template.summary);
+    expect(maxStudents.value).toBe(template.maxStudents.toString());
+    expect(image.value).toBe(template.image);
+
+    template.tags.forEach((tag) => {
+      const chip = screen.getByText(tag.name);
+      expect(chip).toBeInTheDocument();
+    });
   });
 });

--- a/src/components/CourseTemplateModal/EditTemplateForm.test.tsx
+++ b/src/components/CourseTemplateModal/EditTemplateForm.test.tsx
@@ -167,7 +167,7 @@ describe('EditTemplateForm Autofill Tests', () => {
   });
 
   it('autofills with tags', () => {
-    const { container } = renderWithTheme(
+    renderWithTheme(
       <EditTemplateForm
         templateData={allFields}
         updateTemplate={() => {}}

--- a/src/components/CourseTemplateModal/EditTemplateForm.tsx
+++ b/src/components/CourseTemplateModal/EditTemplateForm.tsx
@@ -14,21 +14,27 @@ import {
 } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import { Controller, useForm } from 'react-hook-form';
-import { TemplateSchemaType } from '@/lib/zod/templates';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { templateSchema, TemplateSchemaType } from '@/lib/zod/templates';
 import FormFieldError from '../FormFieldError';
 import StyledTooltip from '@/components/StyledTooltip';
 import RichTextEditor from '@/components/TextEditor';
 import { Tag } from '@prisma/client';
+import { TemplateWithTags } from '@/lib/prisma/templates';
 
 interface Props extends DictProps {
-  templateId: string;
   updateTemplate: () => void;
   tags: Tag[];
+  templateData: TemplateWithTags;
 }
-
 type FormType = TemplateSchemaType;
 
-export function EditTemplateForm({ lang, updateTemplate, tags }: Props) {
+export function EditTemplateForm({
+  lang,
+  updateTemplate,
+  tags,
+  templateData,
+}: Props) {
   const { t } = useTranslation(lang);
   const { palette } = useTheme();
   const {
@@ -36,7 +42,15 @@ export function EditTemplateForm({ lang, updateTemplate, tags }: Props) {
     register,
     formState: { errors },
   } = useForm<FormType>({
-    defaultValues: {},
+    resolver: zodResolver(templateSchema),
+    defaultValues: {
+      ...(templateData
+        ? {
+            ...templateData,
+            tags: templateData.tags.map((tag) => tag.name),
+          }
+        : { maxStudents: 10 }),
+    },
   });
 
   return (

--- a/src/components/CourseTemplateModal/index.tsx
+++ b/src/components/CourseTemplateModal/index.tsx
@@ -9,9 +9,10 @@ import { EditTemplateForm } from './EditTemplateForm';
 import { useTheme } from '@mui/material/styles';
 import CloseIcon from '@mui/icons-material/Close';
 import { Tag } from '@prisma/client';
+import { TemplateWithTags } from '@/lib/prisma/templates';
 
 interface CourseTemplateModalProps extends DictProps {
-  templateId: string;
+  template: TemplateWithTags;
   open: boolean;
   onClose: () => void;
   tags: Tag[];
@@ -19,7 +20,7 @@ interface CourseTemplateModalProps extends DictProps {
 
 export default function CourseTemplateModal({
   lang,
-  templateId,
+  template,
   onClose,
   tags,
 }: CourseTemplateModalProps) {
@@ -83,7 +84,7 @@ export default function CourseTemplateModal({
           </Box>
           <EditTemplateForm
             tags={tags}
-            templateId={templateId}
+            templateData={template}
             lang={lang}
             updateTemplate={updateTemplate}
           />

--- a/src/components/ProfileView/ProfileTemplateList.tsx
+++ b/src/components/ProfileView/ProfileTemplateList.tsx
@@ -17,7 +17,7 @@ import { TemplateSearchBar } from '@/components/TemplateSearchBar/TemplateSearch
 import { EditTemplateButton } from '@/components/EditTemplate/EditTemplateButton';
 import CourseTemplateModal from '@/components/CourseTemplateModal';
 import { Locale, i18n } from '@/lib/i18n/i18n-config';
-import { TemplateWithCreator } from '@/lib/prisma/templates';
+import { TemplateWithCreator, TemplateWithTags } from '@/lib/prisma/templates';
 
 export interface ProfileCourseListProps {
   headerText: string;
@@ -36,7 +36,8 @@ export default function ProfileTemplateList({
   const { palette } = useTheme();
   const [isCollapsed, setIsCollapsed] = useState(open);
   const [isTemplateModalOpen, setIsTemplateModalOpen] = useState(false);
-  const [selectedTemplate, setSelectedTemplate] = useState<string | null>(null);
+  const [selectedTemplate, setSelectedTemplate] =
+    useState<TemplateWithTags | null>(null);
 
   const handleToggleCollapse = () => {
     setIsCollapsed(!isCollapsed);
@@ -44,8 +45,8 @@ export default function ProfileTemplateList({
 
   const lang: Locale = i18n.defaultLocale;
 
-  const handleEditButtonClick = (templateId: string) => {
-    setSelectedTemplate(templateId);
+  const handleEditButtonClick = (template: TemplateWithTags) => {
+    setSelectedTemplate(template);
     setIsTemplateModalOpen(true);
   };
 
@@ -125,7 +126,7 @@ export default function ProfileTemplateList({
                       <EditTemplateButton
                         templateId={template.id}
                         lang={lang}
-                        onClick={() => handleEditButtonClick(template.id)}
+                        onClick={() => handleEditButtonClick(template)}
                       />
                       <DeleteTemplateButton
                         templateId={template.id}
@@ -145,7 +146,7 @@ export default function ProfileTemplateList({
         <CourseTemplateModal
           tags={tags}
           lang={lang}
-          templateId={selectedTemplate}
+          template={selectedTemplate}
           open={isTemplateModalOpen}
           onClose={handleCloseTemplateModal}
         />


### PR DESCRIPTION
Created a functionality that autofills the template edit form with chosen template's data. Functionality is tested with unit tests.