### PR TITLE
New profile tab for courses created by user

### DIFF
--- a/cypress/e2e/profileView.cy.ts
+++ b/cypress/e2e/profileView.cy.ts
@@ -75,6 +75,9 @@ describe('Profile View', () => {
       cy.contains('Taylor Trainee');
       cy.contains('taylor@traininghub.org');
     });
+    it('should not show my courses tab for trainee', () => {
+      cy.contains('My courses').should('not.exist');
+    });
     it('should not show admin dashboard for trainee', () => {
       cy.contains('Admin dashboard').should('not.exist');
     });
@@ -91,12 +94,6 @@ describe('Profile View', () => {
       cy.getCy('listControls\\.endedCourses').click();
       cy.contains(testCourses[0].name);
     });
-    it('should not show upcoming created courses for trainee', () => {
-      cy.contains('Upcoming created courses').should('not.exist');
-    });
-    it('should not show template list for trainee', () => {
-      cy.contains('My course templates').should('not.exist');
-    });
   });
   describe('when logged in as a trainer', () => {
     beforeEach(() => {
@@ -106,10 +103,14 @@ describe('Profile View', () => {
       cy.getCy('listControls\\.inprogressCourses').click();
       cy.getCy('listControls\\.upcomingCourses').click();
     });
+    it('should show my courses tab for trainer', () => {
+      cy.contains('My courses');
+    });
     it('should not show admin dashboard for trainer', () => {
       cy.contains('Admin dashboard').should('not.exist');
     });
     it('should show upcoming created courses for trainer', () => {
+      cy.getCy('myCoursesTab').click();
       // close ended created courses dropdown
       cy.getCy('listControls\\.endedCreated').click();
       // trainer user is the creator of 2 upcoming courses
@@ -120,6 +121,7 @@ describe('Profile View', () => {
       cy.contains(testCourses[3].name);
     });
     it('should show ended created courses for trainer', () => {
+      cy.getCy('myCoursesTab').click();
       // close upcoming created courses dropdown
       cy.getCy('listControls\\.upcomingCreated').click();
       // trainer user is the creator of one upcoming course
@@ -143,6 +145,7 @@ describe('Profile View', () => {
       cy.contains('No courses to show.');
     });
     it('should show template list for trainer', () => {
+      cy.getCy('myCoursesTab').click();
       // trainer user doesn't have any templates
       cy.contains('My course templates (0)');
     });
@@ -155,20 +158,26 @@ describe('Profile View', () => {
       cy.getCy('listControls\\.inprogressCourses').click();
       cy.getCy('listControls\\.upcomingCourses').click();
     });
+    it('should show my courses tab for trainer', () => {
+      cy.contains('My courses');
+    });
     it('should show admin dashboard for admin', () => {
       cy.contains('Admin dashboard');
     });
     it('should not show upcoming created courses for admin', () => {
+      cy.getCy('myCoursesTab').click();
       // admin isn't the creator of any courses
       cy.contains('Upcoming created courses (0)');
       cy.contains('No courses to show.');
     });
     it('should not show ended created courses for admin', () => {
+      cy.getCy('myCoursesTab').click();
       // admin isn't the creator of any courses
       cy.contains('Ended created courses (0)');
       cy.contains('No courses to show.');
     });
     it('should show all templates for admin', () => {
+      cy.getCy('myCoursesTab').click();
       cy.contains('All course templates (2)');
 
       // open template dropdown

--- a/cypress/e2e/profileView.cy.ts
+++ b/cypress/e2e/profileView.cy.ts
@@ -158,7 +158,7 @@ describe('Profile View', () => {
       cy.getCy('listControls\\.inprogressCourses').click();
       cy.getCy('listControls\\.upcomingCourses').click();
     });
-    it('should show my courses tab for trainer', () => {
+    it('should show my courses tab for admin', () => {
       cy.contains('My courses');
     });
     it('should show admin dashboard for admin', () => {

--- a/cypress/e2e/templateEditing.cy.ts
+++ b/cypress/e2e/templateEditing.cy.ts
@@ -7,8 +7,8 @@ describe('Template editing', () => {
   describe('when logged in as an admin', () => {
     beforeEach(() => {
       cy.login('john.doe@example.com', 'ADMIN');
-      cy.getCy('avatarIconButton').click();
-      cy.getCy('viewProfileMenuItem').click();
+      cy.visit('/profile');
+      cy.getCy('myCoursesTab').click();
       cy.getCy('templateListControls').click();
     });
 
@@ -36,8 +36,8 @@ describe('Template editing', () => {
   describe('when logged in as a trainer', () => {
     beforeEach(() => {
       cy.login('emily.davis@example.com', 'TRAINER');
-      cy.getCy('avatarIconButton').click();
-      cy.getCy('viewProfileMenuItem').click();
+      cy.visit('/profile');
+      cy.getCy('myCoursesTab').click();
       cy.getCy('templateListControls').click();
     });
 

--- a/cypress/e2e/templateList.cy.ts
+++ b/cypress/e2e/templateList.cy.ts
@@ -7,8 +7,8 @@ describe('Template list', () => {
   describe('when logged in as an admin', () => {
     beforeEach(() => {
       cy.login('john.doe@example.com', 'ADMIN');
-      cy.getCy('avatarIconButton').click();
-      cy.getCy('viewProfileMenuItem').click();
+      cy.visit('/profile');
+      cy.getCy('myCoursesTab').click();
       cy.getCy('templateListControls').click();
     });
 
@@ -37,8 +37,8 @@ describe('Template list', () => {
   describe('when logged in as a trainer', () => {
     beforeEach(() => {
       cy.login('emily.davis@example.com', 'TRAINER');
-      cy.getCy('avatarIconButton').click();
-      cy.getCy('viewProfileMenuItem').click();
+      cy.visit('/profile');
+      cy.getCy('myCoursesTab').click();
       cy.getCy('templateListControls').click();
     });
 
@@ -55,8 +55,8 @@ describe('Template list', () => {
   describe('TemplateSearchBar Functionality', () => {
     beforeEach(() => {
       cy.login('john.doe@example.com', 'ADMIN');
-      cy.getCy('avatarIconButton').click();
-      cy.getCy('viewProfileMenuItem').click();
+      cy.visit('/profile');
+      cy.getCy('myCoursesTab').click();
       cy.getCy('templateListControls').click();
     });
 

--- a/src/app/[lang]/locales/en/components.json
+++ b/src/app/[lang]/locales/en/components.json
@@ -117,7 +117,8 @@
     "label": {
       "additionalInfo": "Additional information",
       "adminDashboard": "Admin dashboard",
-      "myCourses": "My courses"
+      "myCourses": "My courses",
+      "myEnrollments": "My enrollments"
     }
   },
   "RemoveCourse": {

--- a/src/components/ProfileView/index.test.tsx
+++ b/src/components/ProfileView/index.test.tsx
@@ -135,7 +135,7 @@ const traineeUser = {
 };
 
 describe('ProfileView Tests', () => {
-  it('should render correct dropdowns for trainee', async () => {
+  it('should render correct dropdowns and tabs for trainee', async () => {
     (useSession as jest.Mock).mockReturnValue({
       data: {
         user: traineeUser,
@@ -160,32 +160,18 @@ describe('ProfileView Tests', () => {
       />
     );
 
-    const myCourses = screen.getByText('ProfileView.label.myCourses');
+    const myEnrollments = screen.getByText('ProfileView.label.myEnrollments');
+    const myCourses = screen.queryByText('ProfileView.label.myCourses');
     const upcomingCourses = screen.getByText(
       'ProfileView.header.upcomingCourses (1)'
     );
     const inProgressCourses = screen.getByText(
       'ProfileView.header.coursesInprogress (1)'
     );
-    const upcomingCreatedCourses = screen.queryByText(
-      'ProfileView.header.upcomingCreatedCourses'
-    );
-    const endedCreatedCourses = screen.queryByText(
-      'ProfileView.header.endedCreatedCourses'
-    );
-    const templatesAdmin = screen.queryByText(
-      'ProfileView.header.templatesAdmin'
-    );
-    const templatesTrainer = screen.queryByText(
-      'ProfileView.header.templatesTrainer'
-    );
-    expect(myCourses).toBeInTheDocument();
+    expect(myEnrollments).toBeInTheDocument();
+    expect(myCourses).not.toBeInTheDocument();
     expect(upcomingCourses).toBeInTheDocument();
     expect(inProgressCourses).toBeInTheDocument();
-    expect(upcomingCreatedCourses).not.toBeInTheDocument();
-    expect(endedCreatedCourses).not.toBeInTheDocument();
-    expect(templatesAdmin).not.toBeInTheDocument();
-    expect(templatesTrainer).not.toBeInTheDocument();
   });
   it('should render correct dropdowns for trainer', async () => {
     (useSession as jest.Mock).mockReturnValue({
@@ -216,6 +202,7 @@ describe('ProfileView Tests', () => {
       />
     );
 
+    const myEnrollments = screen.getByText('ProfileView.label.myEnrollments');
     const myCourses = screen.getByText('ProfileView.label.myCourses');
     const upcomingCourses = screen.getByText(
       'ProfileView.header.upcomingCourses (1)'
@@ -223,6 +210,12 @@ describe('ProfileView Tests', () => {
     const inProgressCourses = screen.getByText(
       'ProfileView.header.coursesInprogress (1)'
     );
+    expect(myEnrollments).toBeInTheDocument();
+    expect(myCourses).toBeInTheDocument();
+    expect(upcomingCourses).toBeInTheDocument();
+    expect(inProgressCourses).toBeInTheDocument();
+
+    fireEvent.click(myCourses);
     const upcomingCreatedCourses = screen.getByText(
       'ProfileView.header.upcomingCreatedCourses (0)' // trainers created courses are in the past
     );
@@ -235,9 +228,6 @@ describe('ProfileView Tests', () => {
     const templatesTrainer = screen.getByText(
       'ProfileView.header.templatesTrainer (1)'
     );
-    expect(myCourses).toBeInTheDocument();
-    expect(upcomingCourses).toBeInTheDocument();
-    expect(inProgressCourses).toBeInTheDocument();
     expect(upcomingCreatedCourses).toBeInTheDocument();
     expect(endedCreatedCourses).toBeInTheDocument();
     expect(templatesAdmin).not.toBeInTheDocument();
@@ -271,6 +261,7 @@ describe('ProfileView Tests', () => {
       />
     );
 
+    const myEnrollments = screen.getByText('ProfileView.label.myEnrollments');
     const myCourses = screen.getByText('ProfileView.label.myCourses');
     const upcomingCourses = screen.getByText(
       'ProfileView.header.upcomingCourses (1)'
@@ -278,6 +269,12 @@ describe('ProfileView Tests', () => {
     const inProgressCourses = screen.getByText(
       'ProfileView.header.coursesInprogress (1)'
     );
+    expect(myEnrollments).toBeInTheDocument();
+    expect(myCourses).toBeInTheDocument();
+    expect(upcomingCourses).toBeInTheDocument();
+    expect(inProgressCourses).toBeInTheDocument();
+
+    fireEvent.click(myCourses);
     const upcomingCreatedCourses = screen.getByText(
       'ProfileView.header.upcomingCreatedCourses (1)'
     );
@@ -290,9 +287,6 @@ describe('ProfileView Tests', () => {
     const templatesTrainer = screen.queryByText(
       'ProfileView.header.templatesTrainer (1)'
     );
-    expect(myCourses).toBeInTheDocument();
-    expect(upcomingCourses).toBeInTheDocument();
-    expect(inProgressCourses).toBeInTheDocument();
     expect(upcomingCreatedCourses).toBeInTheDocument();
     expect(endedCreatedCourses).toBeInTheDocument();
     expect(templatesAdmin).toBeInTheDocument();

--- a/src/components/ProfileView/index.test.tsx
+++ b/src/components/ProfileView/index.test.tsx
@@ -173,10 +173,10 @@ describe('ProfileView Tests', () => {
     const endedCreatedCourses = screen.queryByText(
       'ProfileView.header.endedCreatedCourses'
     );
-    const tempaltesAdmin = screen.queryByText(
+    const templatesAdmin = screen.queryByText(
       'ProfileView.header.templatesAdmin'
     );
-    const tempaltesTrainer = screen.queryByText(
+    const templatesTrainer = screen.queryByText(
       'ProfileView.header.templatesTrainer'
     );
     expect(myCourses).toBeInTheDocument();
@@ -184,8 +184,8 @@ describe('ProfileView Tests', () => {
     expect(inProgressCourses).toBeInTheDocument();
     expect(upcomingCreatedCourses).not.toBeInTheDocument();
     expect(endedCreatedCourses).not.toBeInTheDocument();
-    expect(tempaltesAdmin).not.toBeInTheDocument();
-    expect(tempaltesTrainer).not.toBeInTheDocument();
+    expect(templatesAdmin).not.toBeInTheDocument();
+    expect(templatesTrainer).not.toBeInTheDocument();
   });
   it('should render correct dropdowns for trainer', async () => {
     (useSession as jest.Mock).mockReturnValue({
@@ -229,10 +229,10 @@ describe('ProfileView Tests', () => {
     const endedCreatedCourses = screen.getByText(
       'ProfileView.header.endedCreatedCourses (1)'
     );
-    const tempaltesAdmin = screen.queryByText(
+    const templatesAdmin = screen.queryByText(
       'ProfileView.header.templatesAdmin (1)'
     );
-    const tempaltesTrainer = screen.getByText(
+    const templatesTrainer = screen.getByText(
       'ProfileView.header.templatesTrainer (1)'
     );
     expect(myCourses).toBeInTheDocument();
@@ -240,8 +240,8 @@ describe('ProfileView Tests', () => {
     expect(inProgressCourses).toBeInTheDocument();
     expect(upcomingCreatedCourses).toBeInTheDocument();
     expect(endedCreatedCourses).toBeInTheDocument();
-    expect(tempaltesAdmin).not.toBeInTheDocument();
-    expect(tempaltesTrainer).toBeInTheDocument();
+    expect(templatesAdmin).not.toBeInTheDocument();
+    expect(templatesTrainer).toBeInTheDocument();
   });
   it('should render correct dropdowns for admin', async () => {
     (useSession as jest.Mock).mockReturnValue({
@@ -284,10 +284,10 @@ describe('ProfileView Tests', () => {
     const endedCreatedCourses = screen.getByText(
       'ProfileView.header.endedCreatedCourses (0)' // there are no ended courses that were created by the admin
     );
-    const tempaltesAdmin = screen.getByText(
+    const templatesAdmin = screen.getByText(
       'ProfileView.header.templatesAdmin (1)'
     );
-    const tempaltesTrainer = screen.queryByText(
+    const templatesTrainer = screen.queryByText(
       'ProfileView.header.templatesTrainer (1)'
     );
     expect(myCourses).toBeInTheDocument();
@@ -295,8 +295,8 @@ describe('ProfileView Tests', () => {
     expect(inProgressCourses).toBeInTheDocument();
     expect(upcomingCreatedCourses).toBeInTheDocument();
     expect(endedCreatedCourses).toBeInTheDocument();
-    expect(tempaltesAdmin).toBeInTheDocument();
-    expect(tempaltesTrainer).not.toBeInTheDocument();
+    expect(templatesAdmin).toBeInTheDocument();
+    expect(templatesTrainer).not.toBeInTheDocument();
   });
   it('should be possible to access admin dashboard as an admin', async () => {
     (useSession as jest.Mock).mockReturnValue({

--- a/src/components/ProfileView/index.tsx
+++ b/src/components/ProfileView/index.tsx
@@ -5,12 +5,12 @@ import ProfileCourseList from '@/components/ProfileView/ProfileCourseList';
 import ProfileTemplateList from '@/components/ProfileView/ProfileTemplateList';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
-import { Course, Role, User } from '@prisma/client';
+import { Course, User } from '@prisma/client';
 import { PropsWithChildren, SyntheticEvent, useState } from 'react';
 import { useTheme } from '@mui/material/styles';
 import { useSession } from 'next-auth/react';
 import UserList from '@/components/UserList';
-import { isTrainerOrAdmin } from '@/lib/auth-utils';
+import { isTrainerOrAdmin, isAdmin } from '@/lib/auth-utils';
 import { TemplateWithCreator } from '@/lib/prisma/templates';
 import { Tag } from '@prisma/client';
 import { DictProps } from '@i18n/index';
@@ -74,35 +74,17 @@ export default function ProfileView({
           },
         }}
       >
-        <Tab label={t('ProfileView.label.myCourses')} />
-        <Tab label={t('ProfileView.label.additionalInfo')} />
-        {session?.user.role === Role.ADMIN && (
+        <Tab label={t('ProfileView.label.myEnrollments')} />
+        {isTrainerOrAdmin((session?.user as User) || {}) && (
+          <Tab label={t('ProfileView.label.myCourses')} />
+        )}
+        {isAdmin((session?.user as User) || {}) && (
           <Tab label={t('ProfileView.label.adminDashboard')} />
         )}
       </Tabs>
 
       {selectedTab === 0 && (
         <>
-          {isTrainerOrAdmin((session?.user as User) || {}) && (
-            <ProfileCourseList
-              headerText={t('ProfileView.header.upcomingCreatedCourses')}
-              courses={createdCourses.filter(
-                (createdCourse: Course) => createdCourse.startDate > currentDate
-              )}
-              open={true}
-              id={'upcomingCreated'}
-            />
-          )}
-          {isTrainerOrAdmin((session?.user as User) || {}) && (
-            <ProfileCourseList
-              headerText={t('ProfileView.header.endedCreatedCourses')}
-              courses={createdCourses.filter(
-                (createdCourse: Course) => createdCourse.endDate < currentDate
-              )}
-              open={true}
-              id={'endedCreated'}
-            />
-          )}
           <ProfileCourseList
             headerText={t('ProfileView.header.coursesInprogress')}
             courses={courses.filter(
@@ -129,18 +111,36 @@ export default function ProfileView({
             open={false}
             id={'endedCourses'}
           />
-          {isTrainerOrAdmin((session?.user as User) || {}) && (
-            <ProfileTemplateList
-              headerText={
-                session?.user.role === Role.ADMIN
-                  ? t('ProfileView.header.templatesAdmin')
-                  : t('ProfileView.header.templatesTrainer')
-              }
-              templates={templates}
-              tags={tags}
-              open={false}
-            />
-          )}
+        </>
+      )}
+      {selectedTab === 1 && (
+        <>
+          <ProfileCourseList
+            headerText={t('ProfileView.header.upcomingCreatedCourses')}
+            courses={createdCourses.filter(
+              (createdCourse: Course) => createdCourse.startDate > currentDate
+            )}
+            open={true}
+            id={'upcomingCreated'}
+          />
+          <ProfileCourseList
+            headerText={t('ProfileView.header.endedCreatedCourses')}
+            courses={createdCourses.filter(
+              (createdCourse: Course) => createdCourse.endDate < currentDate
+            )}
+            open={true}
+            id={'endedCreated'}
+          />
+          <ProfileTemplateList
+            headerText={
+              isAdmin((session?.user as User) || {})
+                ? t('ProfileView.header.templatesAdmin')
+                : t('ProfileView.header.templatesTrainer')
+            }
+            templates={templates}
+            tags={tags}
+            open={false}
+          />
         </>
       )}
       {selectedTab === 2 && (

--- a/src/components/ProfileView/index.tsx
+++ b/src/components/ProfileView/index.tsx
@@ -74,12 +74,21 @@ export default function ProfileView({
           },
         }}
       >
-        <Tab label={t('ProfileView.label.myEnrollments')} />
+        <Tab
+          label={t('ProfileView.label.myEnrollments')}
+          data-testid="myEnrollmentsTab"
+        />
         {isTrainerOrAdmin((session?.user as User) || {}) && (
-          <Tab label={t('ProfileView.label.myCourses')} />
+          <Tab
+            label={t('ProfileView.label.myCourses')}
+            data-testid="myCoursesTab"
+          />
         )}
         {isAdmin((session?.user as User) || {}) && (
-          <Tab label={t('ProfileView.label.adminDashboard')} />
+          <Tab
+            label={t('ProfileView.label.adminDashboard')}
+            data-testid="adminDashboardTab"
+          />
         )}
       </Tabs>
 


### PR DESCRIPTION
The profile view now has a new tab, "My Courses" (old tab renamed to "My Enrollments"). This tab is only visible for trainers/admins. The dropdowns courses and templates created by the user have been moved here.

E2E tests involving the profile page have been amended, and now test for the visibility of the new tab.