### PR TITLE
Fix course card grid view

### DIFF
--- a/src/components/CourseList/index.tsx
+++ b/src/components/CourseList/index.tsx
@@ -186,8 +186,6 @@ export default function CourseList({
           {viewStyle === 'grid' && (
             <Grid
               container
-              display={'flex'}
-              justifyContent={'space-between'}
               maxWidth={1600}
               width="100%"
               sx={{ margin: 'auto' }}


### PR DESCRIPTION
Grid view shows course cards next to each other without extra spacing