### PR TITLE
Fix template saving in course edit view

### DIFF
--- a/src/components/CourseForm/TemplateSelect/index.tsx
+++ b/src/components/CourseForm/TemplateSelect/index.tsx
@@ -5,10 +5,10 @@ import Select, { SelectChangeEvent } from '@mui/material/Select';
 import { useTheme } from '@mui/material/styles';
 import { useState } from 'react';
 import { UseFormSetValue } from 'react-hook-form';
-import { CourseSchemaType } from '@/lib/zod/courses';
+import { CourseSchemaWithIdType } from '@/lib/zod/courses';
 import { TemplateWithTags } from '@/lib/prisma/templates';
 
-type FormType = CourseSchemaType;
+type FormType = CourseSchemaWithIdType;
 
 interface TemplateSelectProps {
   id: string;

--- a/src/components/CourseForm/index.tsx
+++ b/src/components/CourseForm/index.tsx
@@ -16,7 +16,6 @@ import { Controller, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import {
   courseSchema,
-  CourseSchemaType,
   courseSchemaWithId,
   CourseSchemaWithIdType,
 } from '@/lib/zod/courses';
@@ -42,7 +41,7 @@ interface CourseFormProps extends DictProps {
   templates: TemplateWithTags[];
 }
 
-type FormType = CourseSchemaType | CourseSchemaWithIdType;
+type FormType = CourseSchemaWithIdType;
 
 export default function CourseForm({
   courseData,
@@ -99,15 +98,17 @@ export default function CourseForm({
   };
 
   const submitTemplate = async (data: FormType) => {
-    // Destructure the data object, omitting date information
+    // Destructure the data object, omitting information not required for templates
     const {
       startDate: _startDate,
       endDate: _endDate,
       lastEnrollDate: _lastEnrollDate,
       lastCancelDate: _lastCancelDate,
-      ...dataWithoutDates
+      createdById: _createdById,
+      id: _id,
+      ...dataWithoutExtras
     } = data;
-    const responseJson = await post('/api/template', dataWithoutDates);
+    const responseJson = await post('/api/template', dataWithoutExtras);
 
     notify(responseJson);
 


### PR DESCRIPTION
The user can now save a template from the course editing view. 

I had to change FormType in CourseForm to always be of type CourseSchemaWithIdType for this and I'm fairly confident it didn't break anything, but just something to be aware of.