### PR TITLE
#444/fix/course modal cant be opened in profile for courses not enrolled in

### DIFF
--- a/src/app/[lang]/profile/page.tsx
+++ b/src/app/[lang]/profile/page.tsx
@@ -35,7 +35,7 @@ export default async function ProfilePage({ searchParams, params }: Props) {
     notFound();
   }
   const allCourses = userData?.createdCourses.concat(userData?.courses) ?? [];
-  const courseIds = allCourses.map((course) => course.id);
+  const enrolledCourseIds = userData.courses.map((course) => course.id) ?? [];
   const openedCourse = allCourses.find(
     (course) => course.id === searchParams.courseId
   );
@@ -54,7 +54,7 @@ export default async function ProfilePage({ searchParams, params }: Props) {
       <CourseModal
         lang={params.lang}
         course={openedCourse}
-        usersEnrolledCourseIds={courseIds}
+        usersEnrolledCourseIds={enrolledCourseIds}
         enrolledStudents={enrolledStudents}
         enrolls={t('CourseModal.enrolls', {
           studentCount: openedCourse?._count.students,

--- a/src/app/[lang]/profile/page.tsx
+++ b/src/app/[lang]/profile/page.tsx
@@ -34,8 +34,9 @@ export default async function ProfilePage({ searchParams, params }: Props) {
   if (!userData) {
     notFound();
   }
-  const courseIds = userData?.courses.map((course) => course.id) ?? [];
-  const openedCourse = userData?.courses.find(
+  const allCourses = userData?.createdCourses.concat(userData?.courses) ?? [];
+  const courseIds = allCourses.map((course) => course.id);
+  const openedCourse = allCourses.find(
     (course) => course.id === searchParams.courseId
   );
 

--- a/src/components/ProfileView/index.tsx
+++ b/src/components/ProfileView/index.tsx
@@ -130,6 +130,7 @@ export default function ProfileView({
               (createdCourse: Course) => createdCourse.startDate > currentDate
             )}
             open={true}
+            timer={true}
             id={'upcomingCreated'}
           />
           <ProfileCourseList

--- a/src/lib/prisma/users.ts
+++ b/src/lib/prisma/users.ts
@@ -29,7 +29,20 @@ export async function getUserData(userId: string) {
         orderBy: [{ startDate: 'asc' }, { name: 'asc' }],
       },
       createdCourses: {
-        orderBy: [{ name: 'asc' }],
+        include: {
+          createdBy: {
+            select: {
+              name: true,
+            },
+          },
+          tags: true,
+          _count: {
+            select: {
+              students: true,
+            },
+          },
+        },
+        orderBy: [{ startDate: 'asc' }, { name: 'asc' }],
       },
       createdTemplates: {
         orderBy: [{ name: 'asc' }],


### PR DESCRIPTION
Any course in profile view can now be opened as a course modal, whether the user is enrolled in the course or not. This is accomplished by making sure that the data for both sets of courses is fetched when loading the profile page.

Also added a timer to the upcoming created courses list to mirror the behaviour of upcoming enrolled courses.