### PR TITLE
Add Slack channel creation backend functionality

### DIFF
--- a/docs/production-setup-guide.md
+++ b/docs/production-setup-guide.md
@@ -65,6 +65,7 @@ Slack setup is required for sending messages to Slack.
     - Here you can obtain `Bot User OAuth Token` for `SLACK_BOT_TOKEN`.
   - Bot Token Scopes:
     - `channels:read`
+    - `channels:manage`
     - `chat:write`
     - `users:read`
     - `users:read.email`

--- a/src/app/[lang]/locales/en/api.json
+++ b/src/app/[lang]/locales/en/api.json
@@ -30,6 +30,7 @@
     "youHaveAlreadyRequested": "You have already requested!"
   },
   "Slack": {
+    "channelAlreadyExists": "Channel already exists",
     "channelCreationFailed": "Failed to create channel",
     "channelCreationSuccess": "Channel created successfully!"
   },

--- a/src/app/[lang]/locales/en/api.json
+++ b/src/app/[lang]/locales/en/api.json
@@ -29,6 +29,10 @@
     "requestSuccessfull": "Request successfully sent!",
     "youHaveAlreadyRequested": "You have already requested!"
   },
+  "Slack": {
+    "channelCreationFailed": "Failed to create channel",
+    "channelCreationSuccess": "Channel created successfully!"
+  },
   "Tags": {
     "duplicateError": "Failed to create tag. A duplicate tag already exists.",
     "tagCreated": "The tag was succesfully created!",

--- a/src/app/api/course/request/route.ts
+++ b/src/app/api/course/request/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from 'next/server';
-import { courseRequestSchema } from '@/lib/zod/courses';
+import { courseIdSchema } from '@/lib/zod/courses';
 import { prisma } from '@/lib/prisma';
 import { getServerAuthSession } from '@/lib/auth';
 import {
@@ -17,7 +17,7 @@ export async function POST(request: NextRequest) {
     const session = await getServerAuthSession();
     const userId = session.user.id;
     const data = await request.json();
-    const { courseId } = courseRequestSchema.parse(data);
+    const { courseId } = courseIdSchema.parse(data);
 
     const course = await prisma.course.findFirst({
       where: { id: courseId },

--- a/src/app/api/course/request/route.ts
+++ b/src/app/api/course/request/route.ts
@@ -77,7 +77,7 @@ export async function PUT(request: NextRequest) {
     const session = await getServerAuthSession();
     const userId = session.user.id;
     const data = await request.json();
-    const { courseId } = courseRequestSchema.parse(data);
+    const { courseId } = courseIdSchema.parse(data);
 
     const course = await prisma.course.findFirst({
       where: { id: courseId },

--- a/src/app/api/course/route.ts
+++ b/src/app/api/course/route.ts
@@ -71,7 +71,6 @@ export async function POST(request: NextRequest) {
 
 export async function PUT(request: NextRequest) {
   try {
-    console.log('course update');
     const { t } = await translator('api');
     const { user } = await getServerAuthSession();
     const body = courseSchemaWithId.parse(await request.json());

--- a/src/app/api/course/route.ts
+++ b/src/app/api/course/route.ts
@@ -71,6 +71,7 @@ export async function POST(request: NextRequest) {
 
 export async function PUT(request: NextRequest) {
   try {
+    console.log('course update');
     const { t } = await translator('api');
     const { user } = await getServerAuthSession();
     const body = courseSchemaWithId.parse(await request.json());

--- a/src/app/api/course/route.ts
+++ b/src/app/api/course/route.ts
@@ -2,7 +2,7 @@ import { NextResponse, NextRequest } from 'next/server';
 import {
   courseSchema,
   courseSchemaWithId,
-  courseDeleteSchema,
+  courseIdSchema,
 } from '@/lib/zod/courses';
 import {
   StatusCodeType,
@@ -122,7 +122,7 @@ export async function DELETE(request: NextRequest) {
     const { user } = await getServerAuthSession();
 
     const reqData = await request.json();
-    const courseData = courseDeleteSchema.parse(reqData);
+    const courseData = courseIdSchema.parse(reqData);
 
     const course = await prisma.course.findFirst({
       where: { id: courseData.courseId },

--- a/src/app/api/slack/channel/route.test.ts
+++ b/src/app/api/slack/channel/route.test.ts
@@ -1,0 +1,112 @@
+import { getServerAuthSession } from '@/lib/auth';
+import { Role } from '@prisma/client';
+import { prisma, clearDatabase } from '@/lib/prisma';
+import { createMocks } from 'node-mocks-http';
+import { NextRequest } from 'next/server';
+import { POST } from './route';
+
+const traineeUser = {
+  id: 'cls1rqioq000008jlf156ate0',
+  role: Role.TRAINEE,
+};
+
+const trainerUser = {
+  id: 'cls6jt0ck000k08lfdsrq9hll',
+  role: Role.TRAINER,
+};
+
+const courseDataWithDate = {
+  id: 'cloh5jr6h000008l40614d1vr',
+  name: 'Spaghetti coding 101',
+  description: 'Security by obscurity',
+  startDate: new Date(Date.now() + 1000 * 60 * 60 * 24),
+  endDate: new Date(Date.now() + 1000 * 60 * 60 * 24 * 2),
+  lastEnrollDate: new Date(Date.now() + 1000 * 60 * 60 * 24),
+  lastCancelDate: new Date(Date.now() + 1000 * 60 * 60 * 12),
+  maxStudents: 200,
+  createdById: trainerUser.id,
+  tags: [],
+};
+
+jest.mock('../../../../lib/auth', () => ({
+  getServerAuthSession: jest.fn(),
+}));
+
+beforeEach(async () => {
+  await clearDatabase();
+  await prisma.user.createMany({
+    data: [traineeUser, trainerUser],
+  });
+});
+
+const mockPostRequest = (body: any) => {
+  return createMocks<NextRequest>({
+    method: 'POST',
+    json: () => body,
+  }).req;
+};
+
+describe('Slack channel API tests', () => {
+  describe('POST', () => {
+    it('Forbidden if user is a trainee', async () => {
+      (getServerAuthSession as jest.Mock).mockImplementation(async () =>
+        Promise.resolve({
+          user: traineeUser,
+        })
+      );
+
+      const courseInDb = await prisma.course.create({
+        data: {
+          ...courseDataWithDate,
+          tags: {
+            connect: [],
+          },
+        },
+      });
+
+      const req = mockPostRequest({ courseId: courseInDb?.id });
+      const response = await POST(req);
+      const data = await response.json();
+      expect(data.message).toBe('Forbidden');
+      expect(data.messageType).toBe('error');
+    });
+
+    it('Fails if course not in db', async () => {
+      (getServerAuthSession as jest.Mock).mockImplementation(async () =>
+        Promise.resolve({
+          user: trainerUser,
+        })
+      );
+
+      const req = mockPostRequest({ courseId: 'cloh5jr6h000008l40614d1vr' });
+      const response = await POST(req);
+      const data = await response.json();
+      expect(data.message).toBe('Course by the given id was not found!');
+      expect(data.messageType).toBe('error');
+    });
+
+    it('Fails if course already has a slack channel', async () => {
+      (getServerAuthSession as jest.Mock).mockImplementation(async () =>
+        Promise.resolve({
+          user: trainerUser,
+        })
+      );
+
+      const courseInDb = await prisma.course.create({
+        data: {
+          ...courseDataWithDate,
+          slackChannelId: '123456',
+          tags: {
+            connect: [],
+          },
+        },
+      });
+
+      const req = mockPostRequest({ courseId: courseInDb?.id });
+      const response = await POST(req);
+      const data = await response.json();
+      expect(data.message).toBe('Channel already exists');
+      expect(data.messageType).toBe('error');
+    });
+  });
+});

--- a/src/app/api/slack/channel/route.ts
+++ b/src/app/api/slack/channel/route.ts
@@ -1,0 +1,52 @@
+import { handleCommonErrors } from '@/lib/response/errorUtil';
+import { NextRequest } from 'next/server';
+import { getServerAuthSession } from '@/lib/auth';
+import { createChannelForCourse } from '@/lib/slack';
+import { prisma } from '@/lib/prisma';
+import { errorResponse, successResponse } from '@/lib/response/responseUtil';
+import { translator } from '@/lib/i18n';
+import { StatusCodeType } from '@/lib/response/responseUtil';
+import { isTrainerOrAdmin } from '@/lib/auth-utils';
+import { courseIdSchema } from '@/lib/zod/courses';
+
+export async function POST(request: NextRequest) {
+  try {
+    console.log('got to post request');
+    const { t } = await translator('api');
+    const { user } = await getServerAuthSession();
+    console.log('starting course parse');
+    const body = courseIdSchema.parse(await request.json());
+    console.log('starting course search');
+    const course = await prisma.course.findFirst({
+      where: { id: body.courseId },
+    });
+
+    if (!isTrainerOrAdmin(user)) {
+      return errorResponse({
+        message: t('Common.forbidden'),
+        statusCode: StatusCodeType.FORBIDDEN,
+      });
+    }
+    if (!course) {
+      return errorResponse({
+        message: t('Common.courseNotFound'),
+        statusCode: StatusCodeType.NOT_FOUND,
+      });
+    }
+
+    const response = await createChannelForCourse(course);
+    if (!response.ok) {
+      return errorResponse({
+        message: `Failed to create channel: ${response.error}`,
+        statusCode: StatusCodeType.BAD_REQUEST,
+      });
+    }
+
+    return successResponse({
+      message: 'Channel created',
+      statusCode: StatusCodeType.CREATED,
+    });
+  } catch (error) {
+    return handleCommonErrors(error);
+  }
+}

--- a/src/app/api/slack/channel/route.ts
+++ b/src/app/api/slack/channel/route.ts
@@ -34,12 +34,10 @@ export async function POST(request: NextRequest) {
     const response = await createChannelForCourse(course);
     if (!response.ok) {
       return errorResponse({
-        message: `Failed to create channel: ${response.error}`,
+        message: `${t('Slack.channelCreationFailed')}: ${response.error}`,
         statusCode: StatusCodeType.BAD_REQUEST,
       });
     }
-
-    console.log(response);
 
     await prisma.course.update({
       where: { id: body.courseId },
@@ -49,7 +47,7 @@ export async function POST(request: NextRequest) {
     });
 
     return successResponse({
-      message: 'Channel created',
+      message: t('Slack.channelCreationSuccess'),
       statusCode: StatusCodeType.CREATED,
     });
   } catch (error) {

--- a/src/app/api/slack/channel/route.ts
+++ b/src/app/api/slack/channel/route.ts
@@ -39,6 +39,15 @@ export async function POST(request: NextRequest) {
       });
     }
 
+    console.log(response);
+
+    await prisma.course.update({
+      where: { id: body.courseId },
+      data: {
+        slackChannelId: response.channel.id,
+      },
+    });
+
     return successResponse({
       message: 'Channel created',
       statusCode: StatusCodeType.CREATED,

--- a/src/app/api/slack/channel/route.ts
+++ b/src/app/api/slack/channel/route.ts
@@ -11,12 +11,9 @@ import { courseIdSchema } from '@/lib/zod/courses';
 
 export async function POST(request: NextRequest) {
   try {
-    console.log('got to post request');
     const { t } = await translator('api');
     const { user } = await getServerAuthSession();
-    console.log('starting course parse');
     const body = courseIdSchema.parse(await request.json());
-    console.log('starting course search');
     const course = await prisma.course.findFirst({
       where: { id: body.courseId },
     });

--- a/src/lib/response/fetchUtil.ts
+++ b/src/lib/response/fetchUtil.ts
@@ -11,6 +11,7 @@ export const get = async (url: RequestInfo | URL) => {
 };
 
 export const post = async (url: RequestInfo | URL, data?: unknown) => {
+  console.log('got to post');
   return await commonBody(url, data, 'POST');
 };
 
@@ -42,10 +43,12 @@ const commonBody = async (
   data: unknown,
   method: string
 ) => {
+  console.log('got to commonbody');
   const response = await fetch(url, {
     method: method,
     body: JSON.stringify(data),
   });
+  console.log(response);
   return await responseToJson(response);
 };
 

--- a/src/lib/response/fetchUtil.ts
+++ b/src/lib/response/fetchUtil.ts
@@ -11,7 +11,6 @@ export const get = async (url: RequestInfo | URL) => {
 };
 
 export const post = async (url: RequestInfo | URL, data?: unknown) => {
-  console.log('got to post');
   return await commonBody(url, data, 'POST');
 };
 
@@ -43,12 +42,10 @@ const commonBody = async (
   data: unknown,
   method: string
 ) => {
-  console.log('got to commonbody');
   const response = await fetch(url, {
     method: method,
     body: JSON.stringify(data),
   });
-  console.log(response);
   return await responseToJson(response);
 };
 

--- a/src/lib/slack/constants.ts
+++ b/src/lib/slack/constants.ts
@@ -10,3 +10,5 @@ export const SLACK_API_CREATE_CHANNEL =
   'https://slack.com/api/conversations.create';
 
 export const SLACK_NEW_TRAININGS_CHANNEL = 'new-trainings';
+
+export const SLACK_CHANNEL_PREFIX = 'tmp-traininghub-';

--- a/src/lib/slack/constants.ts
+++ b/src/lib/slack/constants.ts
@@ -6,4 +6,7 @@ export const SLACK_API_LOOKUP_BY_EMAIL =
 export const SLACK_API_LOOKUP_BY_CHANNEL =
   'https://slack.com/api/conversations.list';
 
+export const SLACK_API_CREATE_CHANNEL =
+  'https://slack.com/api/conversations.create';
+
 export const SLACK_NEW_TRAININGS_CHANNEL = 'new-trainings';

--- a/src/lib/slack/index.ts
+++ b/src/lib/slack/index.ts
@@ -65,9 +65,12 @@ export const sendCoursePoster = async (course: Course) => {
 };
 
 export const createChannelForCourse = async (course: Course) => {
-  const channelName =
+  let channelName =
     SLACK_CHANNEL_PREFIX +
     course.name.toLowerCase().replace('[^a-z0-9s-]', '').replace(/\s/g, '-');
+  if (channelName.length > 80) {
+    channelName = channelName.substring(0, 80);
+  }
 
   return await createNewChannel(channelName);
 };

--- a/src/lib/slack/index.ts
+++ b/src/lib/slack/index.ts
@@ -108,6 +108,6 @@ const sendMessage = async (channel: string, blocks: Block[]) => {
 
 const sendMessageToUser = async (userEmail: string, blocks: Block[]) => {
   const userId = await findUserIdByEmail(userEmail);
-  if (!userEmail) return;
+  if (!userId) return;
   await sendMessage(userId, blocks);
 };

--- a/src/lib/slack/index.ts
+++ b/src/lib/slack/index.ts
@@ -3,6 +3,7 @@ import {
   SLACK_API_LOOKUP_BY_CHANNEL,
   SLACK_API_LOOKUP_BY_EMAIL,
   SLACK_API_POST_MESSAGE,
+  SLACK_API_CREATE_CHANNEL,
   SLACK_NEW_TRAININGS_CHANNEL,
 } from './constants';
 import { createBlocksCourseFull, createBlocksNewTraining } from './blocks';
@@ -47,6 +48,31 @@ export const sendCoursePoster = async (course: Course) => {
   if (!channelExistsResult) return;
   const message = createBlocksNewTraining(course);
   await sendMessage(channel, message);
+};
+
+export const createChannelForCourse = async (course: Course) => {
+  console.log('got to createChannelForCourse');
+  const channelName = course.name
+    .toLowerCase()
+    //.replace('[^a-z0-9\s-]', '')
+    .replace(/\s/g, '-');
+
+  console.log(channelName);
+  return await createNewChannel(channelName);
+};
+
+export const createNewChannel = async (channel_name: string) => {
+  const res = await fetch(SLACK_API_CREATE_CHANNEL, {
+    method: 'POST',
+    body: JSON.stringify({ name: channel_name }),
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/json',
+    },
+  });
+  const data = await res.json();
+  return data;
 };
 
 const channelExists = async (channel: string) => {

--- a/src/lib/slack/index.ts
+++ b/src/lib/slack/index.ts
@@ -65,6 +65,7 @@ export const sendCoursePoster = async (course: Course) => {
 };
 
 export const createChannelForCourse = async (course: Course) => {
+  if (!isProduction()) return { ok: false, error: 'not_production' };
   let channelName =
     SLACK_CHANNEL_PREFIX +
     course.name.toLowerCase().replace('[^a-z0-9s-]', '').replace(/\s/g, '-');
@@ -75,7 +76,7 @@ export const createChannelForCourse = async (course: Course) => {
   return await createNewChannel(channelName);
 };
 
-export const createNewChannel = async (channel_name: string) => {
+const createNewChannel = async (channel_name: string) => {
   const res = await fetch(SLACK_API_CREATE_CHANNEL, {
     method: 'POST',
     body: JSON.stringify({ name: channel_name }),

--- a/src/lib/slack/index.ts
+++ b/src/lib/slack/index.ts
@@ -5,6 +5,7 @@ import {
   SLACK_API_POST_MESSAGE,
   SLACK_API_CREATE_CHANNEL,
   SLACK_NEW_TRAININGS_CHANNEL,
+  SLACK_CHANNEL_PREFIX,
 } from './constants';
 import { createBlocksCourseFull, createBlocksNewTraining } from './blocks';
 import { isProduction } from '../env-utils';
@@ -51,10 +52,9 @@ export const sendCoursePoster = async (course: Course) => {
 };
 
 export const createChannelForCourse = async (course: Course) => {
-  const channelName = course.name
-    .toLowerCase()
-    .replace('[^a-z0-9s-]', '')
-    .replace(/\s/g, '-');
+  const channelName =
+    SLACK_CHANNEL_PREFIX +
+    course.name.toLowerCase().replace('[^a-z0-9s-]', '').replace(/\s/g, '-');
 
   return await createNewChannel(channelName);
 };

--- a/src/lib/slack/index.ts
+++ b/src/lib/slack/index.ts
@@ -51,13 +51,11 @@ export const sendCoursePoster = async (course: Course) => {
 };
 
 export const createChannelForCourse = async (course: Course) => {
-  console.log('got to createChannelForCourse');
   const channelName = course.name
     .toLowerCase()
-    //.replace('[^a-z0-9\s-]', '')
+    .replace('[^a-z0-9s-]', '')
     .replace(/\s/g, '-');
 
-  console.log(channelName);
   return await createNewChannel(channelName);
 };
 

--- a/src/lib/zod/courses.ts
+++ b/src/lib/zod/courses.ts
@@ -123,18 +123,6 @@ export const courseEnrollSchema = z
   })
   .strict();
 
-export const courseDeleteSchema = z
-  .object({
-    courseId: z.string().cuid(),
-  })
-  .strict();
-
-export const courseRequestSchema = z
-  .object({
-    courseId: z.string().cuid(),
-  })
-  .strict();
-
 export const courseIdSchema = z
   .object({
     courseId: z.string().cuid(),

--- a/src/lib/zod/courses.ts
+++ b/src/lib/zod/courses.ts
@@ -107,6 +107,7 @@ const courseSchemaBase = z
 const courseSchemaBaseWithId = courseSchemaBase.extend({
   id: z.string().min(1),
   createdById: z.string(),
+  slackChannelId: z.string().nullish(),
 });
 
 export const courseSchema = withRefine(courseSchemaBase);
@@ -129,6 +130,12 @@ export const courseDeleteSchema = z
   .strict();
 
 export const courseRequestSchema = z
+  .object({
+    courseId: z.string().cuid(),
+  })
+  .strict();
+
+export const courseIdSchema = z
   .object({
     courseId: z.string().cuid(),
   })


### PR DESCRIPTION
You can now make a POST request to /api/slack/channel with a Course ID to create a Slack channel for the course.

The channel name is prefixed with "tmp-traininghub-", followed by the course name in lowercase, with spaces changed to hyphens and special characters removed. The channel ID is saved to the course's slackChannelId field in the database. 

Also refactored the identical courseDeleteSchema and courseRequestSchema functions into the courseIdSchema function, which is also used in the Slack channel creation.