### PR TITLE
Add check for empty description field when editing course

### DIFF
--- a/src/lib/zod/courses.ts
+++ b/src/lib/zod/courses.ts
@@ -67,6 +67,7 @@ const courseSchemaBase = z
     description: z
       .string()
       .min(1)
+      .regex(/^(?!<p><\/p>$).+$/)
       .transform((desc) => DOMPurify.sanitize(desc)),
     startDate: z
       .string()


### PR DESCRIPTION
Now correctly checks that description field isn't empty when submitting an edited course. 

Note: Still accepts blank-ish values such as " ", but this functions the same way when creating a course.