### PR TITLE
#510/feat/add new changes to slack update message

### DIFF
--- a/src/app/api/course/route.ts
+++ b/src/app/api/course/route.ts
@@ -133,7 +133,7 @@ export async function PUT(request: NextRequest) {
       // Send notification of course update to each user in slack
       if (courseWithUsers) {
         for (const user of courseWithUsers.students) {
-          await sendCourseUpdate(courseWithUsers, user.email || '');
+          await sendCourseUpdate(course, courseWithUsers, user.email || '');
         }
       }
     }

--- a/src/lib/slack/blocks.ts
+++ b/src/lib/slack/blocks.ts
@@ -222,6 +222,94 @@ export const createBlocksUpdatedTraining = (
     });
   }
 
+  if (
+    !(
+      updatedCourse.lastEnrollDate?.toString() ===
+      oldCourse.lastEnrollDate?.toString()
+    )
+  ) {
+    if (oldCourse.lastEnrollDate && updatedCourse.lastEnrollDate) {
+      blocks.push({
+        type: 'context',
+        elements: [
+          {
+            type: 'mrkdwn',
+            text: ':bangbang:',
+          },
+          {
+            type: 'mrkdwn',
+            text: `~*Enrollment deadline:* ${formatDateForSlack(
+              oldCourse.lastEnrollDate
+            )}~ :arrow_right: *Enrollment deadline:* ${formatDateForSlack(
+              updatedCourse.lastEnrollDate
+            )}`,
+          },
+        ],
+      });
+    }
+    if (updatedCourse.lastEnrollDate && !oldCourse.lastEnrollDate) {
+      blocks.push({
+        type: 'context',
+        elements: [
+          {
+            type: 'mrkdwn',
+            text: ':bangbang:',
+          },
+          {
+            type: 'mrkdwn',
+            text: `*Enrollment deadline:* ${formatDateForSlack(
+              updatedCourse.lastEnrollDate
+            )}`,
+          },
+        ],
+      });
+    }
+  }
+
+  if (
+    !(
+      updatedCourse.lastCancelDate?.toString() ===
+      oldCourse.lastCancelDate?.toString()
+    )
+  ) {
+    if (oldCourse.lastCancelDate && updatedCourse.lastCancelDate) {
+      blocks.push({
+        type: 'context',
+        elements: [
+          {
+            type: 'mrkdwn',
+            text: ':bangbang:',
+          },
+          {
+            type: 'mrkdwn',
+            text: `~*Cancellation deadline:* ${formatDateForSlack(
+              oldCourse.lastCancelDate
+            )}~ :arrow_right: *Cancellation deadline:* ${formatDateForSlack(
+              updatedCourse.lastCancelDate
+            )}`,
+          },
+        ],
+      });
+    }
+    if (updatedCourse.lastCancelDate && !oldCourse.lastCancelDate) {
+      blocks.push({
+        type: 'context',
+        elements: [
+          {
+            type: 'mrkdwn',
+            text: ':bangbang:',
+          },
+          {
+            type: 'mrkdwn',
+            text: `*Cancellation deadline:* ${formatDateForSlack(
+              updatedCourse.lastCancelDate
+            )}`,
+          },
+        ],
+      });
+    }
+  }
+
   if (!(updatedCourse.maxStudents === oldCourse.maxStudents)) {
     blocks.push({
       type: 'context',

--- a/src/lib/slack/blocks.ts
+++ b/src/lib/slack/blocks.ts
@@ -164,7 +164,7 @@ export const createBlocksUpdatedTraining = (
       type: 'header',
       text: {
         type: 'plain_text',
-        text: 'Training details updated:exclamation::mag:',
+        text: 'Training details updated!',
         emoji: true,
       },
     },
@@ -189,7 +189,7 @@ export const createBlocksUpdatedTraining = (
         },
         {
           type: 'mrkdwn',
-          text: `~${oldCourse.name}~ :point_right: ${updatedCourse.name}`,
+          text: ` ~${oldCourse.name}~ :arrow_right: ${updatedCourse.name}`,
         },
       ],
     });
@@ -210,10 +210,10 @@ export const createBlocksUpdatedTraining = (
         },
         {
           type: 'mrkdwn',
-          text: `~${formatDateRangeForSlack(
+          text: ` ~${formatDateRangeForSlack(
             oldCourse.startDate,
             oldCourse.endDate
-          )}~ :point_right: ${formatDateRangeForSlack(
+          )}~ :arrow_right: ${formatDateRangeForSlack(
             updatedCourse.startDate,
             updatedCourse.endDate
           )}`,
@@ -232,7 +232,7 @@ export const createBlocksUpdatedTraining = (
         },
         {
           type: 'mrkdwn',
-          text: `~${oldCourse.maxStudents}~ :point_right: ${updatedCourse.maxStudents} spots`,
+          text: `~${oldCourse.maxStudents} spots~ :arrow_right: ${updatedCourse.maxStudents} spots`,
         },
       ],
     });

--- a/src/lib/slack/blocks.ts
+++ b/src/lib/slack/blocks.ts
@@ -155,8 +155,11 @@ export const createBlocksNewTraining = (course: Course) => {
   return blocks;
 };
 
-export const createBlocksUpdatedTraining = (course: Course) => {
-  return [
+export const createBlocksUpdatedTraining = (
+  oldCourse: Course,
+  updatedCourse: Course
+) => {
+  const blocks = [
     {
       type: 'header',
       text: {
@@ -166,13 +169,39 @@ export const createBlocksUpdatedTraining = (course: Course) => {
       },
     },
     {
-      type: 'section',
-      text: {
-        type: 'mrkdwn',
-        text: `*<${process.env.HOST_URL}/en?courseId=${course.id}|${course.name}>* has recent updates. Check it out!`,
-      },
+      type: 'context',
+      elements: [
+        {
+          type: 'mrkdwn',
+          text: `*<${process.env.HOST_URL}/en?courseId=${updatedCourse.id}|${updatedCourse.name}>* has recent updates:`,
+        },
+      ],
     },
-    {
+  ];
+
+  if (!(updatedCourse.name === oldCourse.name)) {
+    blocks.push({
+      type: 'context',
+      elements: [
+        {
+          type: 'mrkdwn',
+          text: ':pencil2:',
+        },
+        {
+          type: 'mrkdwn',
+          text: `~${oldCourse.name}~ :point_right: ${updatedCourse.name}`,
+        },
+      ],
+    });
+  }
+
+  if (
+    !(
+      updatedCourse.startDate.toString() === oldCourse.startDate.toString() &&
+      updatedCourse.endDate.toString() === oldCourse.endDate.toString()
+    )
+  ) {
+    blocks.push({
       type: 'context',
       elements: [
         {
@@ -181,11 +210,35 @@ export const createBlocksUpdatedTraining = (course: Course) => {
         },
         {
           type: 'mrkdwn',
-          text: formatDateRangeForSlack(course.startDate, course.endDate),
+          text: `~${formatDateRangeForSlack(
+            oldCourse.startDate,
+            oldCourse.endDate
+          )}~ :point_right: ${formatDateRangeForSlack(
+            updatedCourse.startDate,
+            updatedCourse.endDate
+          )}`,
         },
       ],
-    },
-  ];
+    });
+  }
+
+  if (!(updatedCourse.maxStudents === oldCourse.maxStudents)) {
+    blocks.push({
+      type: 'context',
+      elements: [
+        {
+          type: 'mrkdwn',
+          text: ':busts_in_silhouette:',
+        },
+        {
+          type: 'mrkdwn',
+          text: `~${oldCourse.maxStudents}~ :point_right: ${updatedCourse.maxStudents} spots`,
+        },
+      ],
+    });
+  }
+
+  return blocks;
 };
 
 const formatDateForSlack = (date: Date) => {

--- a/src/lib/slack/index.ts
+++ b/src/lib/slack/index.ts
@@ -76,9 +76,13 @@ export const sendCoursePoster = async (course: Course) => {
   await sendMessage(channel, message);
 };
 
-export const sendCourseUpdate = async (course: Course, userEmail: string) => {
+export const sendCourseUpdate = async (
+  oldCourseData: Course,
+  updatedCourseData: Course,
+  userEmail: string
+) => {
   if (!isProduction()) return;
-  const blocks = createBlocksUpdatedTraining(course);
+  const blocks = createBlocksUpdatedTraining(oldCourseData, updatedCourseData);
   await sendMessageToUser(userEmail, blocks);
 };
 


### PR DESCRIPTION
If trainer chooses to send Slack notification to course participants about updated course, the message now includes the changed details. This functionality shows whether title, dates, enrollment deadlines or participant capacity of the course has been changed.