### PR TITLE
Add timestamps to requesters view

### DIFF
--- a/src/app/[lang]/locales/en/components.json
+++ b/src/app/[lang]/locales/en/components.json
@@ -1,16 +1,15 @@
 {
   "AddSlackButton": {
     "button": "slack",
-
     "tooltip": {
       "active": "Creates a slack channel for this course",
       "disabled": "The slack channel for this course exists already"
     }
   },
-
   "AttendeeList": {
     "header": {
-      "text": "Attendees"
+      "name": "Name",
+      "requestDate": "Request Date"
     },
     "noAttendeesText": "No enrolled students",
     "noRequestsText": "No requests"

--- a/src/components/AttendeeTable/index.test.tsx
+++ b/src/components/AttendeeTable/index.test.tsx
@@ -1,6 +1,7 @@
 import AttendeeTable from '.';
 import { renderWithTheme } from '@/lib/test-utils';
 import { UserNamesAndIds } from '@/lib/prisma/users';
+import { RequestsAndUserNames } from '@/lib/prisma/requests';
 import { screen } from '@testing-library/react';
 
 const enrolledStudents: UserNamesAndIds = [
@@ -26,33 +27,112 @@ const enrolledStudents: UserNamesAndIds = [
   },
 ];
 
+const requestList: RequestsAndUserNames = [
+  {
+    id: 'req1',
+    user: {
+      name: 'Terry Tester',
+    },
+    name: 'Terry Tester',
+    userId: 'requester1',
+    courseId: 'course1',
+    date: new Date('2021-10-10T10:00:00'),
+  },
+  {
+    id: 'req2',
+    user: {
+      name: 'Harper Hacker',
+    },
+    name: 'Harper Hacker',
+    userId: 'requester2',
+    courseId: 'course2',
+    date: new Date('2021-11-10T10:00:00'),
+  },
+];
+
+jest.mock('../../lib/i18n/client', () => ({
+  // this mock makes sure any components using the translate hook can use it without a warning being shown
+  useTranslation: () => {
+    return {
+      t: (str: string) => str,
+      i18n: {
+        changeLanguage: () => new Promise(() => {}),
+      },
+    };
+  },
+}));
+
 const noEnrolledStudentsText = 'No enrolled students';
+const noRequestsText = 'No requests';
+
+const lang = 'en';
 
 describe('AttendeeTable component', () => {
-  it('Displays all course attendees', async () => {
-    renderWithTheme(
-      <AttendeeTable
-        attendees={enrolledStudents}
-        noAttendeesText={noEnrolledStudentsText}
-      />
-    );
+  describe('When displaying enrollments', () => {
+    it('Displays all course attendees', async () => {
+      renderWithTheme(
+        <AttendeeTable
+          attendees={enrolledStudents}
+          noAttendeesText={noEnrolledStudentsText}
+          lang={lang}
+        />
+      );
 
-    enrolledStudents.forEach((student) => {
-      expect(screen.getByText(student.name)).toBeInTheDocument();
+      enrolledStudents.forEach((student) => {
+        expect(screen.getByText(student.name)).toBeInTheDocument();
+      });
+    });
+
+    it('Displays message text but no table if the list with enrolled students is empty', async () => {
+      renderWithTheme(
+        <AttendeeTable
+          attendees={[]}
+          noAttendeesText={noEnrolledStudentsText}
+          lang={lang}
+        />
+      );
+
+      const noStudentsText = screen.getByText(noEnrolledStudentsText);
+      expect(noStudentsText).toBeInTheDocument();
+
+      const nameTable = screen.queryByRole('table', {
+        name: 'enrolled students table',
+      });
+      expect(nameTable).not.toBeInTheDocument();
     });
   });
 
-  it('Displays message text but no table if the list with enrollled students is empty', async () => {
-    renderWithTheme(
-      <AttendeeTable attendees={[]} noAttendeesText={noEnrolledStudentsText} />
-    );
+  describe('When displaying requesters', () => {
+    it('Displays all course requesters', async () => {
+      renderWithTheme(
+        <AttendeeTable
+          attendees={requestList}
+          noAttendeesText={noRequestsText}
+          lang={lang}
+        />
+      );
 
-    const noStudentsText = screen.getByText(noEnrolledStudentsText);
-    expect(noStudentsText).toBeInTheDocument();
-
-    const nameTable = screen.queryByRole('table', {
-      name: 'enrolled students table',
+      requestList.forEach((request) => {
+        expect(request.name).toBeDefined();
+        if (request.name) {
+          expect(screen.getByText(request.name)).toBeInTheDocument();
+        }
+      });
     });
-    expect(nameTable).not.toBeInTheDocument();
+    it('Displays all request dates', async () => {
+      renderWithTheme(
+        <AttendeeTable
+          attendees={requestList}
+          noAttendeesText={noRequestsText}
+          lang={lang}
+        />
+      );
+
+      requestList.forEach((request) => {
+        expect(
+          screen.getByText(request.date.toDateString())
+        ).toBeInTheDocument();
+      });
+    });
   });
 });

--- a/src/components/AttendeeTable/index.tsx
+++ b/src/components/AttendeeTable/index.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { DictProps } from '@/lib/i18n';
 import { RequestsAndUserNames } from '@/lib/prisma/requests';
 import { UserNamesAndIds } from '@/lib/prisma/users';
 import Paper from '@mui/material/Paper';
@@ -13,15 +14,21 @@ import TablePagination from '@mui/material/TablePagination';
 import TableRow from '@mui/material/TableRow';
 import Typography from '@mui/material/Typography';
 import { useState } from 'react';
+import { useTranslation } from '@/lib/i18n/client';
 
-interface Props {
+interface Props extends DictProps {
   attendees: UserNamesAndIds | RequestsAndUserNames;
   noAttendeesText: string;
 }
 
-export default function AttendeeTable({ attendees, noAttendeesText }: Props) {
+export default function AttendeeTable({
+  attendees,
+  noAttendeesText,
+  lang,
+}: Props) {
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(10);
+  const { t } = useTranslation(lang, 'components');
 
   if (!attendees) return null;
 
@@ -73,8 +80,12 @@ export default function AttendeeTable({ attendees, noAttendeesText }: Props) {
         >
           <TableHead>
             <TableRow>
-              <TableCell>Name</TableCell>
-              {requests && <TableCell align="right">Request Date</TableCell>}
+              <TableCell>{t('AttendeeList.header.name')}</TableCell>
+              {requests && (
+                <TableCell align="right">
+                  {t('AttendeeList.header.requestDate')}
+                </TableCell>
+              )}
             </TableRow>
           </TableHead>
           <TableBody>

--- a/src/components/AttendeeTable/index.tsx
+++ b/src/components/AttendeeTable/index.tsx
@@ -33,6 +33,8 @@ export default function AttendeeTable({ attendees, noAttendeesText }: Props) {
     );
   }
 
+  const requests = attendees as RequestsAndUserNames;
+
   const handleChangePage = (
     _event: React.MouseEvent<HTMLButtonElement, MouseEvent> | null,
     newPage: number
@@ -70,6 +72,7 @@ export default function AttendeeTable({ attendees, noAttendeesText }: Props) {
           <TableHead>
             <TableRow>
               <TableCell>Name</TableCell>
+              {requests && <TableCell align="right">Request Date</TableCell>}
             </TableRow>
           </TableHead>
           <TableBody>
@@ -78,6 +81,13 @@ export default function AttendeeTable({ attendees, noAttendeesText }: Props) {
               .map((attendee) => (
                 <TableRow key={attendee.userId}>
                   <TableCell>{attendee.name}</TableCell>
+                  {requests && (
+                    <TableCell align="right">
+                      {requests
+                        .find((request) => request.userId === attendee.userId)
+                        ?.date.toDateString()}
+                    </TableCell>
+                  )}
                 </TableRow>
               ))}
             {emptyRows > 0 && (

--- a/src/components/AttendeeTable/index.tsx
+++ b/src/components/AttendeeTable/index.tsx
@@ -33,7 +33,9 @@ export default function AttendeeTable({ attendees, noAttendeesText }: Props) {
     );
   }
 
-  const requests = attendees as RequestsAndUserNames;
+  const requests = attendees[0].hasOwnProperty('date')
+    ? (attendees as RequestsAndUserNames)
+    : null;
 
   const handleChangePage = (
     _event: React.MouseEvent<HTMLButtonElement, MouseEvent> | null,

--- a/src/components/CourseModal/index.tsx
+++ b/src/components/CourseModal/index.tsx
@@ -260,6 +260,7 @@ export default function CourseModal({
           <AttendeeTable
             attendees={enrolledStudents || []}
             noAttendeesText={t('AttendeeList.noAttendeesText')}
+            lang={lang}
           />
         )}
 
@@ -267,6 +268,7 @@ export default function CourseModal({
           <AttendeeTable
             attendees={requests || []}
             noAttendeesText={t('AttendeeList.noRequestsText')}
+            lang={lang}
           />
         )}
 

--- a/src/lib/prisma/requests.ts
+++ b/src/lib/prisma/requests.ts
@@ -13,6 +13,9 @@ export async function getRequestsByCourseId(courseId: string) {
         },
       },
     },
+    orderBy: {
+      date: 'desc',
+    },
   });
   return requests.map((request) => ({
     ...request,


### PR DESCRIPTION
The UI for viewing the requests a course has received now shows timestamps for the date each request was made. The requests are ordered by the date of the request (descending).

Also added i18n integration to AttendeeTable, and created tests for the new functionality.