### PR TITLE
Add backend functionality for adding and deleting participations

### DIFF
--- a/prisma/migrations/20240321135604_add_participation_tracking_to_database/migration.sql
+++ b/prisma/migrations/20240321135604_add_participation_tracking_to_database/migration.sql
@@ -1,0 +1,14 @@
+-- CreateTable
+CREATE TABLE "Participation" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "courseId" TEXT NOT NULL,
+
+    CONSTRAINT "Participation_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "Participation" ADD CONSTRAINT "Participation_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Participation" ADD CONSTRAINT "Participation_courseId_fkey" FOREIGN KEY ("courseId") REFERENCES "Course"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20240321155622_add_unique_constraint_to_participations/migration.sql
+++ b/prisma/migrations/20240321155622_add_unique_constraint_to_participations/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[userId,courseId]` on the table `Participation` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "Participation_userId_courseId_key" ON "Participation"("userId", "courseId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,24 +19,25 @@ enum Role {
 }
 
 model User {
-  id               String     @id @default(cuid())
+  id               String          @id @default(cuid())
   name             String?
-  email            String?    @unique
+  email            String?         @unique
   emailVerified    DateTime?
   countryId        String?
-  country          Country?   @relation(name: "country", fields: [countryId], references: [id])
+  country          Country?        @relation(name: "country", fields: [countryId], references: [id])
   titleId          String?
-  title            Title?     @relation(name: "title", fields: [titleId], references: [id])
+  title            Title?          @relation(name: "title", fields: [titleId], references: [id])
   image            String?
   courses          Course[]
-  createdCourses   Course[]   @relation(name: "createdCourses")
-  createdTemplates Template[] @relation(name: "createdTemplates")
+  createdCourses   Course[]        @relation(name: "createdCourses")
+  createdTemplates Template[]      @relation(name: "createdTemplates")
   requests         Request[]
+  participations   Participation[]
   accounts         Account[]
   sessions         Session[]
-  role             Role       @default(TRAINEE)
+  role             Role            @default(TRAINEE)
   calendar         Calendar[]
-  profileCompleted Boolean    @default(false)
+  profileCompleted Boolean         @default(false)
 }
 
 model Country {
@@ -53,7 +54,7 @@ model Title {
 }
 
 model Course {
-  id             String     @id @default(cuid())
+  id             String          @id @default(cuid())
   name           String
   description    String
   summary        String?
@@ -64,8 +65,9 @@ model Course {
   maxStudents    Int
   students       User[]
   requests       Request[]
+  participations Participation[]
   tags           Tag[]
-  createdBy      User?      @relation(name: "createdCourses", references: [id], fields: [createdById])
+  createdBy      User?           @relation(name: "createdCourses", references: [id], fields: [createdById])
   createdById    String
   calendar       Calendar[]
   image          String?
@@ -79,6 +81,16 @@ model Request {
   course   Course   @relation(fields: [courseId], references: [id])
   courseId String
   date     DateTime
+
+  @@unique([userId, courseId])
+}
+
+model Participation {
+  id       String @id @default(cuid())
+  user     User   @relation(fields: [userId], references: [id])
+  userId   String
+  course   Course @relation(fields: [courseId], references: [id])
+  courseId String
 
   @@unique([userId, courseId])
 }

--- a/src/app/[lang]/locales/en/api.json
+++ b/src/app/[lang]/locales/en/api.json
@@ -25,6 +25,10 @@
     "noEnrollingAfterDeadline": "No enrolling allowed after enrollment deadline",
     "youHaveAlreadyEnrolled": "You have already enrolled!"
   },
+  "Participations": {
+    "participationAdded": "Participation marked",
+    "participationRemoved": "Participation removed"
+  },
   "Requests": {
     "requestRemoved": "Your request was removed",
     "requestSuccessfull": "Request successfully sent!",

--- a/src/app/[lang]/locales/en/api.json
+++ b/src/app/[lang]/locales/en/api.json
@@ -27,6 +27,7 @@
   },
   "Participations": {
     "participationAdded": "Participation marked",
+    "participationNotFound": "Participation not found",
     "participationRemoved": "Participation removed"
   },
   "Requests": {

--- a/src/app/api/course/participation/route.test.ts
+++ b/src/app/api/course/participation/route.test.ts
@@ -1,0 +1,157 @@
+import { createMocks } from 'node-mocks-http';
+import { NextRequest } from 'next/server';
+import { MessageType, StatusCodeType } from '@/lib/response/responseUtil';
+import { clearDatabase } from '@/lib/prisma';
+import { prisma } from '@/lib/prisma';
+import { getServerAuthSession } from '@/lib/auth';
+import { Role } from '@prisma/client';
+import { POST, DELETE } from './route';
+
+const testUser = {
+  id: 'cloeouh4x0000qiexq8tqzvh7',
+};
+
+const trainerUser = {
+  id: 'cls31nwpr000308jycjsj3em1',
+  role: Role.TRAINER,
+};
+
+const traineeUser = {
+  id: 'cls1rqioq000008jlf156ate0',
+  role: Role.TRAINEE,
+};
+
+const testCourse = {
+  id: 'cloeouh4x0000qiexq8tqzvh8',
+  name: 'Git Fundamentals',
+  description:
+    'This course will walk you through the fundamentals of using Git for version control. You will learn how to create a local Git repository, commit files and push your changes to a remote repository. The course will introduce you to concepts like the working copy and the staging area and teach you how to organise you repository using tags and branches. You will learn how to make pull requests and merge branches, and tackle merge conflicts when they arise.',
+  startDate: '2024-01-01T00:00:00Z',
+  endDate: '2024-01-02T00:00:00Z',
+  maxStudents: 3,
+  createdById: testUser.id,
+};
+
+jest.mock('../../../../lib/auth', () => ({
+  getServerAuthSession: jest.fn(),
+}));
+
+const authTrainer = () => {
+  (getServerAuthSession as jest.Mock).mockImplementation(async () =>
+    Promise.resolve({
+      user: trainerUser,
+    })
+  );
+};
+
+const authTrainee = () => {
+  (getServerAuthSession as jest.Mock).mockImplementation(async () =>
+    Promise.resolve({
+      user: traineeUser,
+    })
+  );
+};
+
+const mockPostRequest = (body: any) => {
+  return createMocks<NextRequest>({
+    method: 'POST',
+    json: () => body,
+  }).req;
+};
+
+const mockDeleteRequest = (body: any) => {
+  return createMocks<NextRequest>({
+    method: 'DELETE',
+    json: () => body,
+  }).req;
+};
+
+beforeEach(async () => {
+  await clearDatabase();
+  await prisma.user.create({
+    data: { id: testUser.id },
+  });
+  await prisma.course.create({
+    data: testCourse,
+  });
+});
+
+describe('Course participation API tests', () => {
+  describe('POST', () => {
+    it('trainer can mark participation for valid user on valid course', async () => {
+      authTrainer();
+
+      const req = mockPostRequest({
+        courseId: testCourse.id,
+        userId: testUser.id,
+      });
+      const response = await POST(req);
+      const data = await response.json();
+
+      expect(data.message).toBe('Participation marked');
+      expect(data.messageType).toBe(MessageType.SUCCESS);
+      expect(response.status).toBe(StatusCodeType.CREATED);
+    });
+
+    it('trainee cannot mark participations', async () => {
+      authTrainee();
+
+      const req = mockPostRequest({
+        courseId: testCourse.id,
+        userId: testUser.id,
+      });
+      const response = await POST(req);
+      const data = await response.json();
+
+      expect(data.message).toBe('Forbidden');
+      expect(data.messageType).toBe(MessageType.ERROR);
+      expect(response.status).toBe(StatusCodeType.FORBIDDEN);
+    });
+  });
+
+  describe('DELETE', () => {
+    it('trainer can delete participations with valid data', async () => {
+      authTrainer();
+
+      await prisma.participation.create({
+        data: {
+          userId: testUser.id,
+          courseId: testCourse.id,
+        },
+      });
+
+      const req = mockDeleteRequest({
+        courseId: testCourse.id,
+        userId: testUser.id,
+      });
+      const response = await DELETE(req);
+      const data = await response.json();
+
+      expect(data.message).toBe('Participation removed');
+      expect(data.messageType).toBe(MessageType.SUCCESS);
+      expect(response.status).toBe(StatusCodeType.OK);
+    });
+
+    it('trainee cannot delete participations', async () => {
+      authTrainee();
+
+      await prisma.participation.create({
+        data: {
+          userId: testUser.id,
+          courseId: testCourse.id,
+        },
+      });
+
+      const req = mockDeleteRequest({
+        courseId: testCourse.id,
+        userId: testUser.id,
+      });
+      const response = await DELETE(req);
+      const data = await response.json();
+
+      expect(data.message).toBe('Forbidden');
+      expect(data.messageType).toBe(MessageType.ERROR);
+      expect(response.status).toBe(StatusCodeType.FORBIDDEN);
+    });
+  });
+});

--- a/src/app/api/course/participation/route.ts
+++ b/src/app/api/course/participation/route.ts
@@ -5,8 +5,9 @@ import { prisma } from '@/lib/prisma';
 import { handleCommonErrors } from '@/lib/response/errorUtil';
 import {
   errorResponse,
+  messageResponse,
+  MessageType,
   StatusCodeType,
-  successResponse,
 } from '@/lib/response/responseUtil';
 import { courseAndUserSchema } from '@/lib/zod/courses';
 import { NextRequest } from 'next/server';
@@ -39,8 +40,11 @@ export async function POST(request: NextRequest) {
         },
       },
     });
-    return successResponse({
+
+    return messageResponse({
       message: t('Participations.participationAdded'),
+      messageType: MessageType.SUCCESS,
+      statusCode: StatusCodeType.CREATED,
     });
   } catch (error) {
     return await handleCommonErrors(error);
@@ -67,8 +71,11 @@ export async function DELETE(request: NextRequest) {
         userId: userId,
       },
     });
-    return successResponse({
+
+    return messageResponse({
       message: t('Participations.participationRemoved'),
+      messageType: MessageType.SUCCESS,
+      statusCode: StatusCodeType.OK,
     });
   } catch (error) {
     return await handleCommonErrors(error);

--- a/src/app/api/course/participation/route.ts
+++ b/src/app/api/course/participation/route.ts
@@ -46,3 +46,31 @@ export async function POST(request: NextRequest) {
     return await handleCommonErrors(error);
   }
 }
+
+export async function DELETE(request: NextRequest) {
+  try {
+    const { t } = await translator('api');
+    const session = await getServerAuthSession();
+    const data = await request.json();
+    const { courseId, userId } = courseAndUserSchema.parse(data);
+
+    if (!isTrainerOrAdmin(session.user)) {
+      return errorResponse({
+        message: t('Common.forbidden'),
+        statusCode: StatusCodeType.FORBIDDEN,
+      });
+    }
+
+    await prisma.participation.deleteMany({
+      where: {
+        courseId: courseId,
+        userId: userId,
+      },
+    });
+    return successResponse({
+      message: t('Participations.participationRemoved'),
+    });
+  } catch (error) {
+    return await handleCommonErrors(error);
+  }
+}

--- a/src/app/api/course/participation/route.ts
+++ b/src/app/api/course/participation/route.ts
@@ -1,0 +1,48 @@
+import { getServerAuthSession } from '@/lib/auth';
+import { isTrainerOrAdmin } from '@/lib/auth-utils';
+import { translator } from '@/lib/i18n';
+import { prisma } from '@/lib/prisma';
+import { handleCommonErrors } from '@/lib/response/errorUtil';
+import {
+  errorResponse,
+  StatusCodeType,
+  successResponse,
+} from '@/lib/response/responseUtil';
+import { courseAndUserSchema } from '@/lib/zod/courses';
+import { NextRequest } from 'next/server';
+
+export async function POST(request: NextRequest) {
+  try {
+    const { t } = await translator('api');
+    const session = await getServerAuthSession();
+    const data = await request.json();
+    const { courseId, userId } = courseAndUserSchema.parse(data);
+
+    if (!isTrainerOrAdmin(session.user)) {
+      return errorResponse({
+        message: t('Common.forbidden'),
+        statusCode: StatusCodeType.FORBIDDEN,
+      });
+    }
+
+    prisma.participation.create({
+      data: {
+        user: {
+          connect: {
+            id: userId,
+          },
+        },
+        course: {
+          connect: {
+            id: courseId,
+          },
+        },
+      },
+    });
+    return successResponse({
+      message: t('Participations.participationAdded'),
+    });
+  } catch (error) {
+    return await handleCommonErrors(error);
+  }
+}

--- a/src/app/api/course/request/route.test.ts
+++ b/src/app/api/course/request/route.test.ts
@@ -3,7 +3,6 @@ import { POST, DELETE } from './route';
 import { clearDatabase, prisma } from '@/lib/prisma';
 import { NextRequest } from 'next/server';
 import { createMocks } from 'node-mocks-http';
-import { courseEnrollSchema } from '@/lib/zod/courses';
 
 const testUser = {
   id: 'cloeouh4x0000qiexq8tqzvh7',
@@ -37,7 +36,7 @@ const mockPostRequest = (body: any) => {
   }).req;
 };
 
-const mockUpdateRequest = (body: any) => {
+const mockDeleteRequest = (body: any) => {
   return createMocks<NextRequest>({
     method: 'DELETE',
     json: () => body,
@@ -128,7 +127,7 @@ describe('Course request API tests', () => {
         },
       });
 
-      const req = mockUpdateRequest({ courseId: requestedCourse.id });
+      const req = mockDeleteRequest({ courseId: requestedCourse.id });
       const response = await DELETE(req);
       const data = await response.json();
 
@@ -142,7 +141,7 @@ describe('Course request API tests', () => {
         data: testCourse,
       });
 
-      const req = mockUpdateRequest({ courseId: notRequestedCourse.id });
+      const req = mockDeleteRequest({ courseId: notRequestedCourse.id });
       const response = await DELETE(req);
       const data = await response.json();
 

--- a/src/lib/zod/courses.ts
+++ b/src/lib/zod/courses.ts
@@ -130,4 +130,11 @@ export const courseIdSchema = z
   })
   .strict();
 
+export const courseAndUserSchema = z
+  .object({
+    courseId: z.string().cuid(),
+    userId: z.string().cuid(),
+  })
+  .strict();
+
 export type CourseEnrollSchemaType = z.infer<typeof courseEnrollSchema>;


### PR DESCRIPTION
The database now has a table for participations, and /api/course/participation route has POST and DELETE functions implemented for adding and removing participations. Tests have been created for the API functionality.