### PR TITLE
#533/fix/course creation e2e test that fails from time to time

### DIFF
--- a/cypress/e2e/courseCreation.cy.ts
+++ b/cypress/e2e/courseCreation.cy.ts
@@ -55,7 +55,7 @@ describe('Course creation using template', () => {
     cy.login('trainer@test.com', 'TRAINER');
     cy.visit('/course/create');
 
-    cy.get('#templateSelect').parent().type('{downarrow}{enter}');
+    cy.get('#templateSelect').parent().type('{downarrow}{downarrow}{enter}');
 
     cy.getCy('courseFormStartDate').type(course.startDate);
     cy.getCy('courseFormEndDate').type(course.endDate);

--- a/cypress/e2e/courseCreation.cy.ts
+++ b/cypress/e2e/courseCreation.cy.ts
@@ -2,7 +2,7 @@ const course = {
   name: 'Kubernetes Fundamentals',
   header: 'Learn Kubernetes',
   description:
-    'Take your first steps in using Kubernetes for container orchestration. This course will introduce you to the basic concepts and building blocks of Kubernetes and the architecture of the system. Get ready to start you cloud native journey!',
+    'This course will introduce you to the basic concepts and building blocks of Kubernetes and the architecture of the system.',
   startDate: '2030-06-01T08:30',
   endDate: '2030-07-01T08:30',
   maxStudents: '100',


### PR DESCRIPTION
Fixed one course template test that kept failing locally in cypress. Also shortened test course's description field that potentially caused earlier timed out problems.