### PR TITLE
#512/feat/create link for users in admin view

### DIFF
--- a/src/app/[lang]/profile/[id]/page.tsx
+++ b/src/app/[lang]/profile/[id]/page.tsx
@@ -1,6 +1,10 @@
 import Container from '@mui/material/Container/Container';
 import { getUserData } from '@/lib/prisma/users';
 import { Locale } from '@/lib/i18n/i18n-config';
+import { notFound } from 'next/navigation';
+import { isAdmin } from '@/lib/auth-utils';
+import UnauthorizedError from '@/components/UnauthorizedError';
+import { getServerAuthSession } from '@/lib/auth';
 
 import ProfileUserDetails from '@/components/ProfileView/ProfileUserDetails';
 
@@ -12,8 +16,16 @@ type Props = {
 };
 
 export default async function ProfilePageById({ params }: Props) {
+  const session = await getServerAuthSession();
   const userId = params.id;
   const userData = await getUserData(userId);
+
+  if (!userData) {
+    notFound();
+  }
+  if (!isAdmin(session.user)) {
+    return <UnauthorizedError lang={params.lang} />;
+  }
 
   return (
     <Container maxWidth="md">

--- a/src/app/[lang]/profile/[id]/page.tsx
+++ b/src/app/[lang]/profile/[id]/page.tsx
@@ -16,8 +16,8 @@ export default async function ProfilePageById({ params }: Props) {
   const userData = await getUserData(userId);
 
   return (
-    <Container>
-      <div style={{ paddingTop: '32px', width: '100%' }}>
+    <Container maxWidth="md">
+      <div style={{ paddingBottom: '20px', paddingTop: '32px' }}>
         <ProfileUserDetails
           name={userData?.name ?? ''}
           email={userData?.email ?? ''}

--- a/src/app/[lang]/profile/[id]/page.tsx
+++ b/src/app/[lang]/profile/[id]/page.tsx
@@ -1,0 +1,29 @@
+import Container from '@mui/material/Container/Container';
+import { getUserData } from '@/lib/prisma/users';
+import { Locale } from '@/lib/i18n/i18n-config';
+
+import ProfileUserDetails from '@/components/ProfileView/ProfileUserDetails';
+
+type Props = {
+  params: {
+    id: string;
+    lang: Locale;
+  };
+};
+
+export default async function ProfilePageById({ params }: Props) {
+  const userId = params.id;
+  const userData = await getUserData(userId);
+
+  return (
+    <Container>
+      <div style={{ paddingTop: '32px', width: '100%' }}>
+        <ProfileUserDetails
+          name={userData?.name ?? ''}
+          email={userData?.email ?? ''}
+          image={userData?.image ?? ''}
+        />
+      </div>
+    </Container>
+  );
+}

--- a/src/components/UserList/index.test.tsx
+++ b/src/components/UserList/index.test.tsx
@@ -138,4 +138,18 @@ describe('User list', () => {
     const smallConfirmCard = await screen.findByTestId('small-confirm-card');
     expect(smallConfirmCard).toBeInTheDocument();
   });
+
+  it('renders user links with correct href values', async () => {
+    const testerlink = screen.getByTestId(`${users[0].id}-user-link`);
+    expect(testerlink).toBeInTheDocument();
+    expect(testerlink).toHaveAttribute('href', `/profile/${users[0].id}`);
+
+    const trainerlink = screen.getByTestId(`${users[1].id}-user-link`);
+    expect(trainerlink).toBeInTheDocument();
+    expect(trainerlink).toHaveAttribute('href', `/profile/${users[1].id}`);
+
+    const traineelink = screen.getByTestId(`${users[2].id}-user-link`);
+    expect(traineelink).toBeInTheDocument();
+    expect(traineelink).toHaveAttribute('href', `/profile/${users[2].id}`);
+  });
 });

--- a/src/components/UserList/index.tsx
+++ b/src/components/UserList/index.tsx
@@ -259,7 +259,7 @@ export default function UserList({ lang, users }: Props) {
               <TableRow key={user.id}>
                 <TableCell component="th" scope="row">
                   <Link
-                    href={`profile/?userId=${user.id}`}
+                    href={`profile/${user.id}`}
                     style={{
                       textDecoration: 'none',
                       color: palette.black.main,

--- a/src/components/UserList/index.tsx
+++ b/src/components/UserList/index.tsx
@@ -259,7 +259,7 @@ export default function UserList({ lang, users }: Props) {
               <TableRow key={user.id}>
                 <TableCell component="th" scope="row">
                   <Link
-                    href={`profile/${user.id}`}
+                    href={`/profile/${user.id}`}
                     style={{
                       textDecoration: 'none',
                       color: palette.black.main,

--- a/src/components/UserList/index.tsx
+++ b/src/components/UserList/index.tsx
@@ -260,6 +260,7 @@ export default function UserList({ lang, users }: Props) {
                 <TableCell component="th" scope="row">
                   <Link
                     href={`/profile/${user.id}`}
+                    data-testid={`${user.id}-user-link`}
                     style={{
                       textDecoration: 'none',
                       color: palette.black.main,

--- a/src/components/UserList/index.tsx
+++ b/src/components/UserList/index.tsx
@@ -26,7 +26,9 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 import { $Enums, User } from '@prisma/client';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useEffect, useMemo, useState } from 'react';
 
@@ -82,6 +84,7 @@ export default function UserList({ lang, users }: Props) {
   const { t } = useTranslation(lang, 'admin');
   const { notify } = useMessage();
   const router = useRouter();
+  const { palette } = useTheme();
 
   const [page, setPage] = useState(0);
   const [visibleRowsPerPage, setVisibleRowsPerPage] = useState(5);
@@ -255,7 +258,15 @@ export default function UserList({ lang, users }: Props) {
             {visibleUsers.map((user, userIndex) => (
               <TableRow key={user.id}>
                 <TableCell component="th" scope="row">
-                  {user?.name ?? '-'}
+                  <Link
+                    href={`profile/?userId=${user.id}`}
+                    style={{
+                      textDecoration: 'none',
+                      color: palette.black.main,
+                    }}
+                  >
+                    {user?.name ?? '-'}
+                  </Link>
                 </TableCell>
                 <TableCell component="th" scope="row">
                   {user?.email ?? '-'}


### PR DESCRIPTION
The list of users on admin dashboard now contains links to /profile/[id] pages on each user. Trainers and trainees cannot access these pages. At the moment the user's page only contains ProfileUserDetails (name, email, image).